### PR TITLE
Calculate base width from input frame shape

### DIFF
--- a/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
+++ b/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
@@ -101,12 +101,19 @@ def main():
     space_code = 32
     mean_time = 0
     img_mean = np.array([128, 128, 128], dtype=np.float32)
-    
+    base_width_calculated = False
+
     for frame_id, frame in enumerate(frame_provider):
         current_time = cv2.getTickCount()
         if frame is None:
             break
         
+        if not base_width_calculated:
+            base_width=frame.shape[1]*(base_height/frame.shape[0])
+            base_width=int(base_width/stride)*stride
+            net.set_input_shape((1,3,base_height,base_width))
+            base_width_calculated=True
+
         # fixed when the model was exported
         frame = cv2.resize(frame, dsize=(base_width, base_height))
 

--- a/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
+++ b/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
@@ -114,16 +114,16 @@ def main():
             net.set_input_shape((1,3,base_height,base_width))
             base_width_calculated=True
 
-        # fixed when the model was exported
-        frame = cv2.resize(frame, dsize=(base_width, base_height))
-
         input_scale = base_height / frame.shape[0]
         
+        scaled_img = cv2.resize(frame, dsize=None, fx=input_scale, fy=input_scale)
+        scaled_img = scaled_img[:, 0:scaled_img.shape[1] - (scaled_img.shape[1] % stride)]  # better to pad, but cut out for demo
+
         if fx < 0:  # Focal length is unknown
             fx = np.float32(0.8 * frame.shape[1])
 
         # normalize image between -0.5 and 0.5
-        normalized_img = (frame.astype(np.float32) - img_mean) / 255.0
+        normalized_img = (scaled_img.astype(np.float32) - img_mean) / 255.0
         normalized_img = np.expand_dims(
             # np.rollaxis(normalized_img, 2, 0),
             normalized_img.transpose(2, 0, 1),


### PR DESCRIPTION
ailia SDKのset_input_shapeを使用してアスペクト比を入力画像に近づけるPRです。Convolutionは入力Shapeサイズに依存しない演算なため、入力Blobサイズを書き換えても正常に推論可能です。ヒートマップベースのPoseEstimation系や、画像セグメンテーション、超解像などは入力Blobサイズを書き換えられるものが多いです。Matmulなどの全結合層が入るとBlobサイズは律速されset_input_shapeはエラーを返します。ただし、間にPoolingなどが入って、小数画素数になると破綻するため、stride=8の倍数まで調整しています。