### PR TITLE
FIX: DEEPSORT 'Namespace' object has no attribute 'input' & Video Result save feature

### DIFF
--- a/arcface/arcface.py
+++ b/arcface/arcface.py
@@ -156,10 +156,8 @@ def compare_image_and_video():
     # inference loop
     while(True):
         ret, frame = capture.read()
-        if cv2.waitKey(1) & 0xFF == ord('q'):
+        if (cv2.waitKey(1) & 0xFF == ord('q')) or not ret:
             break
-        if not ret:
-            continue
 
         frame, resized_frame = adjust_frame_size(
             frame, IMAGE_HEIGHT, IMAGE_WIDTH

--- a/blazeface/README.md
+++ b/blazeface/README.md
@@ -30,7 +30,7 @@ $ python3 blazeface.py --input IMAGE_PATH --savepath SAVE_IMAGE_PATH
 By adding the `--video` option, you can input the video.   
 If you pass `0` as an argument to VIDEO_PATH, you can use the webcam input instead of the video file.
 ```bash
-$ python3 blazeface.py --video VIDEO_PATH
+$ python3 blazeface.py --video VIDEO_PATH --savepath SAVE_VIDEO_PATH
 ```
 
 ### Reference

--- a/blazeface/blazeface.py
+++ b/blazeface/blazeface.py
@@ -12,7 +12,7 @@ sys.path.append('../util')
 from utils import check_file_existance  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
-from webcamera_utils import preprocess_frame, calc_adjust_fsize  # noqa: E402
+import webcamera_utils  # noqa: E402
 
 
 # ======================
@@ -119,16 +119,13 @@ def recognize_from_video():
             capture = cv2.VideoCapture(args.video)
 
     # create video writer if savepath is specified as video format
-    f_h = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    f_w = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
-    save_h, save_w = calc_adjust_fsize(f_h, f_w, IMAGE_HEIGHT, IMAGE_WIDTH)
     if args.savepath != SAVE_IMAGE_PATH:
-        writer = cv2.VideoWriter(
-            args.savepath,
-            cv2.VideoWriter_fourcc(*'MJPG'),
-            20,
-            (save_w, save_h)
+        f_h = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        f_w = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+        save_h, save_w = webcamera_utils.calc_adjust_fsize(
+            f_h, f_w, IMAGE_HEIGHT, IMAGE_WIDTH
         )
+        writer = webcamera_utils.get_writer(args.savepath, save_h, save_w)
     else:
         writer = None
 
@@ -137,7 +134,7 @@ def recognize_from_video():
         if (cv2.waitKey(1) & 0xFF == ord('q')) or not ret:
             break
 
-        input_image, input_data = preprocess_frame(
+        input_image, input_data = webcamera_utils.preprocess_frame(
             frame, IMAGE_HEIGHT, IMAGE_WIDTH, normalize_type='127.5'
         )
 

--- a/crowdcount-cascaded-mtl/README.md
+++ b/crowdcount-cascaded-mtl/README.md
@@ -26,7 +26,7 @@ $ python3 crowdcount.py --input IMAGE_PATH --savepath SAVE_IMAGE_PATH
 By adding the `--video` option, you can input the video.
 If you pass `0` as an argument to VIDEO_PATH, you can use the webcam input instead of the video file.
 ```bash
-$ python3 crowdcount.py --video VIDEO_PATH
+$ python3 crowdcount.py --video VIDEO_PATH --savepath SAVE_VIDEO_PATH
 ```
 
 ### Reference

--- a/crowdcount-cascaded-mtl/crowdcount.py
+++ b/crowdcount-cascaded-mtl/crowdcount.py
@@ -144,10 +144,8 @@ def estimate_from_video():
 
     while(True):
         ret, frame = capture.read()
-        if cv2.waitKey(1) & 0xFF == ord('q'):
+        if (cv2.waitKey(1) & 0xFF == ord('q')) or not ret:
             break
-        if not ret:
-            continue
 
         input_image, input_data = webcamera_utils.preprocess_frame(
             frame,

--- a/crowdcount-cascaded-mtl/crowdcount.py
+++ b/crowdcount-cascaded-mtl/crowdcount.py
@@ -11,7 +11,7 @@ sys.path.append('../util')
 from utils import check_file_existance  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from image_utils import load_image  # noqa: E402
-from webcamera_utils import preprocess_frame  # noqa: E402
+import webcamera_utils  # noqa: E402
 
 
 # ======================
@@ -23,8 +23,8 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/crowd_count/"
 
 IMAGE_PATH = 'test.jpeg'
 SAVE_IMAGE_PATH = 'result.png'
-WIDTH = 640
-HEIGHT = 480
+IMAGE_WIDTH = 640
+IMAGE_HEIGHT = 480
 
 
 # ======================
@@ -45,9 +45,9 @@ parser.add_argument(
          'If the VIDEO argument is set to 0, the webcam input will be used.'
 )
 parser.add_argument(
-    '-s', '--savepath', metavar='SAVE_IMAGE_PATH',
+    '-s', '--savepath', metavar='SAVE_PATH',
     default=SAVE_IMAGE_PATH,
-    help='Save path for the output image.'
+    help='Save path for the result of the model.'
 )
 parser.add_argument(
     '-b', '--benchmark',
@@ -63,10 +63,14 @@ args = parser.parse_args()
 # ======================
 def estimate_from_image():
     # prepare input data
-    org_img = load_image(args.input, (HEIGHT, WIDTH), normalize_type='None')
+    org_img = load_image(
+        args.input,
+        (IMAGE_HEIGHT, IMAGE_WIDTH),
+        normalize_type='None'
+    )
     input_data = load_image(
         args.input,
-        (HEIGHT, WIDTH),
+        (IMAGE_HEIGHT, IMAGE_WIDTH),
         rgb=False,
         normalize_type='None',
         gen_input_ailia=True
@@ -93,7 +97,7 @@ def estimate_from_image():
 
     # density map
     density_map = (255 * preds_ailia / np.max(preds_ailia))[0][0]
-    density_map = cv2.resize(density_map, (WIDTH, HEIGHT))
+    density_map = cv2.resize(density_map, (IMAGE_WIDTH, IMAGE_HEIGHT))
     heatmap = cv2.applyColorMap(density_map.astype(np.uint8), cv2.COLORMAP_JET)
     cv2.putText(
         heatmap,
@@ -126,6 +130,18 @@ def estimate_from_video():
         if check_file_existance(args.video):
             capture = cv2.VideoCapture(args.video)
 
+    # create video writer if savepath is specified as video format
+    if args.savepath != SAVE_IMAGE_PATH:
+        f_h = int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        f_w = int(capture.get(cv2.CAP_PROP_FRAME_WIDTH))
+        save_h, save_w = webcamera_utils.calc_adjust_fsize(
+            f_h, f_w, IMAGE_HEIGHT, IMAGE_WIDTH
+        )
+        # save_w * 2: we stack source frame and estimated heatmap
+        writer = webcamera_utils.get_writer(args.savepath, save_h, save_w * 2)
+    else:
+        writer = None
+
     while(True):
         ret, frame = capture.read()
         if cv2.waitKey(1) & 0xFF == ord('q'):
@@ -133,8 +149,12 @@ def estimate_from_video():
         if not ret:
             continue
 
-        input_image, input_data = preprocess_frame(
-            frame, HEIGHT, WIDTH, data_rgb=False, normalize_type='None'
+        input_image, input_data = webcamera_utils.preprocess_frame(
+            frame,
+            IMAGE_HEIGHT,
+            IMAGE_WIDTH,
+            data_rgb=False,
+            normalize_type='None'
         )
 
         # inference
@@ -163,6 +183,11 @@ def estimate_from_video():
         )
         res_img = np.hstack((input_image, heatmap))
         cv2.imshow('frame', res_img)
+
+        # save results
+        if writer is not None:
+            writer.write(res_img)
+
     capture.release()
     cv2.destroyAllWindows()
     print('Script finished successfully.')

--- a/deeplabv3/README.md
+++ b/deeplabv3/README.md
@@ -29,7 +29,7 @@ $ python3 deeplabv3.py --input IMAGE_PATH --savepath SAVE_IMAGE_PATH
 By adding the `--video` option, you can input the video.
 If you pass `0` as an argument to VIDEO_PATH, you can use the webcam input instead of the video file.
 ```bash
-$ python3 deeplabv3.py --video VIDEO_PATH
+$ python3 deeplabv3.py --video VIDEO_PATH --savepath SAVE_VIDEO_PATH
 ```
 
 The default setting is to use the optimized model and weights, but you can also switch to the normal model by using the `--normal` option.

--- a/deepsort/README.md
+++ b/deepsort/README.md
@@ -43,7 +43,7 @@ It is necessary to be connected to the Internet while downloading.
   You can use `--savepath` option to change the name of the output file to save.  
   If you pass `0` as an argument to `VIDEO_PATH`, you can use the webcam input instead of the video.
   ```bash
-  $ python3 deepsort.py --video VIDEO_PATH --savepath SAVE_IMAGE_PATH
+  $ python3 deepsort.py --video VIDEO_PATH --savepath SAVE_VIDEO_PATH
   ```
 
 - compare image mode:

--- a/deepsort/deepsort.py
+++ b/deepsort/deepsort.py
@@ -15,6 +15,7 @@ from utils import check_file_existance  # noqa: E402
 from image_utils import normalize_image  # noqa: E402
 from model_utils import check_and_download_models  # noqa: E402
 from detector_utils import plot_results, load_image  # noqa: E402C
+from webcamera_utils import get_writer  # noqa: E402C
 
 
 # ======================
@@ -130,25 +131,21 @@ def recognize_from_video():
         n_init=3
     )
 
-    if args.input == '0':
+    if args.video == '0':
         print('[INFO] Webcam mode is activated')
         capture = cv2.VideoCapture(0)
         if not capture.isOpened():
             print("[ERROR] webcamera not found")
             sys.exit(1)
     else:
-        if check_file_existance(args.input):
-            capture = cv2.VideoCapture(args.input)
+        if check_file_existance(args.video):
+            capture = cv2.VideoCapture(args.video)
 
     # create video writer
-    writer = cv2.VideoWriter(
+    writer = get_writer(
         args.savepath,
-        cv2.VideoWriter_fourcc(*'MJPG'),
-        20,
-        (
-            int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)),
-            int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT))
-        )
+        int(capture.get(cv2.CAP_PROP_FRAME_HEIGHT)),
+        int(capture.get(cv2.CAP_PROP_FRAME_WIDTH)),
     )
 
     print('Start Inference...')

--- a/util/webcamera_utils.py
+++ b/util/webcamera_utils.py
@@ -4,6 +4,13 @@ import cv2
 from image_utils import normalize_image
 
 
+def calc_adjust_fsize(f_height, f_width, height, width):
+    # calculate the image size of the output('img') of adjust_frame_size
+    # This function is supposed to be used to declare 'cv2.writer'
+    scale = np.max((f_height / height, f_width / width))
+    return int(scale * height), int(scale * width)
+
+
 def adjust_frame_size(frame, height, width):
     """
     Adjust the size of the frame from the webcam to the ailia input shape.

--- a/util/webcamera_utils.py
+++ b/util/webcamera_utils.py
@@ -93,3 +93,13 @@ def preprocess_frame(
         data = cv2.cvtColor(data.astype(np.float32), cv2.COLOR_BGR2GRAY)
         data = data[np.newaxis, np.newaxis, :, :]
     return img, data
+
+
+def get_writer(savepath, height, width):
+    writer = cv2.VideoWriter(
+        savepath,
+        cv2.VideoWriter_fourcc(*'MJPG'),
+        20,
+        (width, height)
+    )
+    return writer


### PR DESCRIPTION
## DEEPSORT
- `args.input`が内部で使用されていたため，`args.video`に変更しました．現masterのものだとエラー担ってしまうと思うので早めのマージをお願い致します．確認不足で申し訳ありません．

## Video Result Save feature
- blazeface, deeplabv3, crowdcount-cascadedにビデオ入力時も結果を保存できるようにしました．
- 同時にループから抜けられなくなっている`if not ret: continue`を`break`に変更も加えています．
- その他のモデルについても順次同じ内容で修正を加えます．