### PR TITLE
Fix mask rcnn opencv version dependency

### DIFF
--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -91,7 +91,7 @@ def preprocess(image):
     image = padded_image[np.newaxis, :, :, :]
     return image
 
-def create_plot():
+def create_figure():
     fig, ax = plt.subplots(1, figsize=(12, 9), tight_layout=True)
     return fig, ax
 
@@ -195,7 +195,7 @@ def recognize_from_image():
         boxes, labels, scores, masks = net.predict([input_data])
 
     # postprocessing
-    fig, ax = create_plot()
+    fig, ax = create_figure()
     display_objdetect_image(
         fig, ax, image, boxes, labels, scores, masks, savepath=args.savepath
     )
@@ -220,7 +220,7 @@ def recognize_from_video():
         if check_file_existance(args.video):
             capture = cv2.VideoCapture(args.video)
 
-    fig, ax = create_plot()
+    fig, ax = create_figure()
 
     while(True):
         ret, frame = capture.read()

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -235,7 +235,7 @@ def recognize_from_video():
 
         boxes, labels, scores, masks = net.predict([input_data])
 
-        fig.clear()
+        ax.clear()
         display_objdetect_image(fig, ax, frame, boxes, labels, scores, masks)
         plt.pause(.01)
 

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -123,9 +123,9 @@ def display_objdetect_image(
         mask = mask > 0.5
         im_mask = np.zeros((image.shape[0], image.shape[1]), dtype=np.uint8)
         x_0 = max(int_box[0], 0)
-        x_1 = min(int_box[2] + 1, image.shape[1])
+        x_1 = min(int_box[2] + 1, int(image.shape[1]))
         y_0 = max(int_box[1], 0)
-        y_1 = min(int_box[3] + 1, image.shape[0])
+        y_1 = min(int_box[3] + 1, int(image.shape[0]))
         mask_y_0 = max(y_0 - box[1], 0)
         mask_y_1 = mask_y_0 + y_1 - y_0
         mask_x_0 = max(x_0 - box[0], 0)

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -177,10 +177,9 @@ def recognize_from_image():
     # net initialize
     env_id = ailia.get_gpu_environment_id()
     print(f'env_id: {env_id}')
-    memory_mode = None
     if env_id != -1 and ailia.get_environment(env_id).props=="LOWPOWER":
-        memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=memory_mode)
+        env_id = -1 # This model requires fuge gpu memory so fallback to cpu mode
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
     net.set_input_shape(input_data.shape)
 
     # inference
@@ -207,10 +206,9 @@ def recognize_from_video():
     # net initialize
     env_id = ailia.get_gpu_environment_id()
     print(f'env_id: {env_id}')
-    memory_mode = None
     if env_id != -1 and ailia.get_environment(env_id).props=="LOWPOWER":
-        memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=memory_mode)
+        env_id = -1 # This model requires fuge gpu memory so fallback to cpu mode
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
 
     if args.video == '0':
         print('[INFO] Webcam mode is activated')

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -176,7 +176,10 @@ def recognize_from_image():
     # net initialize
     env_id = ailia.get_gpu_environment_id()
     print(f'env_id: {env_id}')
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+    memory_mode = None
+    if env_id != -1 and ailia.get_environment(env_id).props=="LOWPOWER":
+        memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=memory_mode)
     net.set_input_shape(input_data.shape)
 
     # inference
@@ -202,7 +205,10 @@ def recognize_from_video():
     # net initialize
     env_id = ailia.get_gpu_environment_id()
     print(f'env_id: {env_id}')
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+    memory_mode = None
+    if env_id != -1 and ailia.get_environment(env_id).props=="LOWPOWER":
+        memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=memory_mode)
 
     if args.video == '0':
         print('[INFO] Webcam mode is activated')

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -125,12 +125,12 @@ def display_objdetect_image(
         mask = mask > 0.5
         im_mask = np.zeros((image.shape[0], image.shape[1]), dtype=np.uint8)
         x_0 = max(int_box[0], 0)
-        x_1 = min(int_box[2] + 1, int(image.shape[1]))
+        x_1 = min(int_box[2] + 1, image.shape[1])
         y_0 = max(int_box[1], 0)
-        y_1 = min(int_box[3] + 1, int(image.shape[0]))
-        mask_y_0 = max(y_0 - box[1], 0)
+        y_1 = min(int_box[3] + 1, image.shape[0])
+        mask_y_0 = max(y_0 - int_box[1], 0)
         mask_y_1 = mask_y_0 + y_1 - y_0
-        mask_x_0 = max(x_0 - box[0], 0)
+        mask_x_0 = max(x_0 - int_box[0], 0)
         mask_x_1 = mask_x_0 + x_1 - x_0
         im_mask[y_0:y_1, x_0:x_1] = mask[
             mask_y_0: mask_y_1, mask_x_0: mask_x_1

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -91,9 +91,12 @@ def preprocess(image):
     image = padded_image[np.newaxis, :, :, :]
     return image
 
+def create_plot():
+    fig, ax = plt.subplots(1, figsize=(12, 9), tight_layout=True)
+    return fig, ax
 
 def display_objdetect_image(
-        image, boxes, labels, scores, masks, score_threshold=0.7, savepath=None
+        fig, ax, image, boxes, labels, scores, masks, score_threshold=0.7, savepath=None
 ):
     """
     Display or Save result
@@ -107,7 +110,6 @@ def display_objdetect_image(
     ratio = 800.0 / min(image.size[0], image.size[1])
     boxes /= ratio
 
-    fig, ax = plt.subplots(1, figsize=(12, 9), tight_layout=True)
     image = np.array(image)
 
     for mask, box, label, score in zip(masks, boxes, labels, scores):
@@ -194,8 +196,9 @@ def recognize_from_image():
         boxes, labels, scores, masks = net.predict([input_data])
 
     # postprocessing
+    fig, ax = create_plot()
     display_objdetect_image(
-        image, boxes, labels, scores, masks, savepath=args.savepath
+        fig, ax, image, boxes, labels, scores, masks, savepath=args.savepath
     )
     print('Script finished successfully.')
 
@@ -219,6 +222,8 @@ def recognize_from_video():
         if check_file_existance(args.video):
             capture = cv2.VideoCapture(args.video)
 
+    fig, ax = create_plot()
+
     while(True):
         ret, frame = capture.read()
         if cv2.waitKey(1) & 0xFF == ord('q'):
@@ -232,7 +237,8 @@ def recognize_from_video():
 
         boxes, labels, scores, masks = net.predict([input_data])
 
-        display_objdetect_image(frame, boxes, labels, scores, masks)
+        fig.clear()
+        display_objdetect_image(fig, ax, frame, boxes, labels, scores, masks)
         plt.pause(.01)
 
     capture.release()

--- a/maskrcnn/maskrcnn.py
+++ b/maskrcnn/maskrcnn.py
@@ -135,10 +135,9 @@ def display_objdetect_image(
         ]
         im_mask = im_mask[:, :, None]
 
-        # OpenCV version 4.x
         contours, hierarchy = cv2.findContours(
             im_mask, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE
-        )
+        )[-2:]  #cv2.findContours has changed since OpenCV 3.x, but in OpenCV 4.0 it changes back
 
         image = cv2.drawContours(image, contours, -1, 25, 3)
 


### PR DESCRIPTION
cv2.findContours has changed since OpenCV 3.x, but in OpenCV 4.0 it changes back
https://www.it-swarm.dev/ja/python/opencv-3%e3%81%aecontourarea%e3%81%a8%e3%81%ae%e4%ba%92%e6%8f%9b%e6%80%a7%e3%81%ae%e5%95%8f%e9%a1%8c/828312249/