### PR TITLE
add enable debug log option for ailia

### DIFF
--- a/action_recognition/mars/mars.py
+++ b/action_recognition/mars/mars.py
@@ -131,7 +131,7 @@ def recognize_from_image():
     input_frame_size = len(sorted_inputs_path)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 3, args.duration, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     # inference
@@ -183,7 +183,7 @@ def recognize_from_video():
     capture = get_capture(args.video)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 3, args.duration, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     # prepare input data

--- a/action_recognition/st_gcn/st_gcn.py
+++ b/action_recognition/st_gcn/st_gcn.py
@@ -340,7 +340,7 @@ def main():
     )
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.arch == "pyopenpose":
         pose = op.WrapperPython()
@@ -351,7 +351,7 @@ def main():
         pose = ailia.PoseEstimator(
             MODEL_POSE_PATH,
             WEIGHT_POSE_PATH,
-            env_id=args.env_id,
+            env_id=args.env_id, debug_log=args.debug,
             algorithm=POSE_ALGORITHM
         )
         if args.arch == "openpose":

--- a/anomaly_detection/padim/padim.py
+++ b/anomaly_detection/padim/padim.py
@@ -415,7 +415,7 @@ def main():
     }
 
     def _create_net():
-        return ailia.Net(model_path, weight_path, env_id=args.env_id)
+        return ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
 
     # net initialize
     if True:

--- a/audio_processing/crnn_audio_classification/crnn_audio_classification.py
+++ b/audio_processing/crnn_audio_classification/crnn_audio_classification.py
@@ -85,7 +85,7 @@ def main():
         data = sf.read(input_data_path)
 
         # create instance
-        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
         # inference
         logger.info('Start inference...')

--- a/audio_processing/deepspeech2/deepspeech2.py
+++ b/audio_processing/deepspeech2/deepspeech2.py
@@ -214,7 +214,7 @@ def wavfile_input_recognition():
         )
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     for soundf_path in args.input:
         logger.info(soundf_path)
@@ -279,7 +279,7 @@ def microphone_input_recognition():
         spectrogram = create_spectrogram(wav)
 
         # net initialize
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
         net.set_input_shape(spectrogram[0].shape)
 
         # inference

--- a/audio_processing/pytorch-dc-tts/pytorch-dc-tts.py
+++ b/audio_processing/pytorch-dc-tts/pytorch-dc-tts.py
@@ -87,8 +87,8 @@ def generate_sentence(sentence):
     L, Y, zeros, A = preprocess(sentence)
 
     # model initialize
-    net_t2m = ailia.Net(MODEL_PATH_T2M, WEIGHT_PATH_T2M, env_id=args.env_id)
-    net_ssrm = ailia.Net(MODEL_PATH_SSRM, WEIGHT_PATH_SSRM, env_id=args.env_id)
+    net_t2m = ailia.Net(MODEL_PATH_T2M, WEIGHT_PATH_T2M, env_id=args.env_id, debug_log=args.debug)
+    net_ssrm = ailia.Net(MODEL_PATH_SSRM, WEIGHT_PATH_SSRM, env_id=args.env_id, debug_log=args.debug)
 
     # inference
     logger.info('Start inference...')

--- a/commercial_model/acculus-pose/acculus-hand.py
+++ b/commercial_model/acculus-pose/acculus-hand.py
@@ -117,13 +117,13 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id
+        env_id=args.env_id, debug_log=args.debug
     )
 
     hand = ailia.PoseEstimator(
         HAND_MODEL_PATH,
         HAND_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         algorithm=HAND_ALGORITHM
     )
     hand.set_threshold(0.1)

--- a/commercial_model/acculus-pose/acculus-pose.py
+++ b/commercial_model/acculus-pose/acculus-pose.py
@@ -125,7 +125,7 @@ def display_result(input_img, pose):
 def recognize_from_image():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
 
     # input image loop
@@ -164,7 +164,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
 
     capture = get_capture(args.video)

--- a/commercial_model/acculus-pose/acculus-up-pose.py
+++ b/commercial_model/acculus-pose/acculus-up-pose.py
@@ -125,7 +125,7 @@ def display_result(input_img, pose):
 def recognize_from_image():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
 
     # input image loop
@@ -165,7 +165,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     shape = pose.get_input_shape()
     logger.info(shape)

--- a/crowd_counting/c-3-framework/c-3-framework.py
+++ b/crowd_counting/c-3-framework/c-3-framework.py
@@ -221,7 +221,7 @@ def main():
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
     # initialize
-    net = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    net = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         recognize_from_video(args.video, net)

--- a/crowd_counting/crowdcount-cascaded-mtl/crowdcount-cascaded-mtl.py
+++ b/crowd_counting/crowdcount-cascaded-mtl/crowdcount-cascaded-mtl.py
@@ -44,7 +44,7 @@ args = update_parser(parser)
 # ======================
 def estimate_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -103,7 +103,7 @@ def estimate_from_image():
 
 def estimate_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/deep_fashion/clothing-detection/clothing-detection.py
+++ b/deep_fashion/clothing-detection/clothing-detection.py
@@ -224,7 +224,7 @@ def main():
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
     # initialize
-    detector = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    detector = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
     id_image_shape = detector.find_blob_index_by_name("image_shape")
     detector.set_input_shape(
         (1, 3, args.detection_width, args.detection_width)

--- a/deep_fashion/fashionai-key-points-detection/fashionai-key-points-detection.py
+++ b/deep_fashion/fashionai-key-points-detection/fashionai-key-points-detection.py
@@ -228,7 +228,7 @@ def main():
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
     # initialize
-    net = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    net = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/deep_fashion/mmfashion/mmfashion.py
+++ b/deep_fashion/mmfashion/mmfashion.py
@@ -243,7 +243,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # initialize
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/depth_estimation/fcrn-depthprediction/fcrn-depthprediction.py
+++ b/depth_estimation/fcrn-depthprediction/fcrn-depthprediction.py
@@ -47,7 +47,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -90,7 +90,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = get_capture(args.video)
 

--- a/depth_estimation/midas/midas.py
+++ b/depth_estimation/midas/midas.py
@@ -230,7 +230,7 @@ def main():
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
     # net initialize
-    net = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    net = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/depth_estimation/monodepth2/monodepth2.py
+++ b/depth_estimation/monodepth2/monodepth2.py
@@ -62,8 +62,8 @@ def result_plot(disp, original_width, original_height):
 # ======================
 def estimate_from_image():
     # net initialize
-    enc_net = ailia.Net(ENC_MODEL_PATH, ENC_WEIGHT_PATH, env_id=args.env_id)
-    dec_net = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id)
+    enc_net = ailia.Net(ENC_MODEL_PATH, ENC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    dec_net = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -102,8 +102,8 @@ def estimate_from_image():
 
 def estimate_from_video():
     # net initialize
-    enc_net = ailia.Net(ENC_MODEL_PATH, ENC_WEIGHT_PATH, env_id=args.env_id)
-    dec_net = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id)
+    enc_net = ailia.Net(ENC_MODEL_PATH, ENC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    dec_net = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_detection/blazeface/blazeface.py
+++ b/face_detection/blazeface/blazeface.py
@@ -47,7 +47,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -91,7 +91,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_detection/dbface/dbface.py
+++ b/face_detection/dbface/dbface.py
@@ -120,7 +120,7 @@ def recognize_from_image(filename):
     logger.debug(f'input image shape: {img.shape}')
     img = cv2.cvtColor(img, cv2.COLOR_BGRA2BGR)
 
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     logger.info('Start inference...')
     if args.benchmark:
@@ -144,7 +144,7 @@ def recognize_from_image(filename):
 
 
 def recognize_from_video(video):
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(video)
 

--- a/face_detection/face-mask-detection/face-mask-detection.py
+++ b/face_detection/face-mask-detection/face-mask-detection.py
@@ -83,7 +83,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=RANGE,
         algorithm=ALGORITHM,
-        env_id=args.env_id
+        env_id=args.env_id, debug_log=args.debug
     )
 
     # input image loop
@@ -136,7 +136,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=RANGE,
         algorithm=ALGORITHM,
-        env_id=args.env_id
+        env_id=args.env_id, debug_log=args.debug
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/face_detection/yolov1-face/yolov1-face.py
+++ b/face_detection/yolov1-face/yolov1-face.py
@@ -58,7 +58,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV1,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     # input image loop
@@ -98,7 +98,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV1,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/face_detection/yolov3-face/yolov3-face.py
+++ b/face_detection/yolov3-face/yolov3-face.py
@@ -56,7 +56,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id
+        env_id=args.env_id, debug_log=args.debug
     )
 
     # input image loop
@@ -96,7 +96,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id
+        env_id=args.env_id, debug_log=args.debug
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/face_identification/arcface/arcface.py
+++ b/face_identification/arcface/arcface.py
@@ -405,7 +405,7 @@ def compare_images():
     imgs = np.concatenate([imgs_1, imgs_2], axis=0)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     BATCH_SIZE = net.get_input_shape()[0]
 
     # inference
@@ -451,12 +451,12 @@ def compare_video():
     tracks = []
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # detector initialize
     if args.face == "blazeface":
         detector = ailia.Net(
-            FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id
+            FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
         )
     else:
         detector = ailia.Detector(
@@ -467,7 +467,7 @@ def compare_video():
             channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
             range=FACE_RANGE,
             algorithm=FACE_ALGORITHM,
-            env_id=args.env_id
+            env_id=args.env_id, debug_log=args.debug
         )
 
     # web camera

--- a/face_identification/insightface/insightface.py
+++ b/face_identification/insightface/insightface.py
@@ -328,9 +328,9 @@ def main():
     check_and_download_models(WEIGHT_GA_PATH, MODEL_GA_PATH, REMOTE_PATH)
 
     # initialize
-    det_model = ailia.Net(MODEL_DET_PATH, WEIGHT_DET_PATH, env_id=args.env_id)
-    rec_model = ailia.Net(MODEL_REC_PATH, WEIGHT_REC_PATH, env_id=args.env_id)
-    ga_model = ailia.Net(MODEL_GA_PATH, WEIGHT_GA_PATH, env_id=args.env_id)
+    det_model = ailia.Net(MODEL_DET_PATH, WEIGHT_DET_PATH, env_id=args.env_id, debug_log=args.debug)
+    rec_model = ailia.Net(MODEL_REC_PATH, WEIGHT_REC_PATH, env_id=args.env_id, debug_log=args.debug)
+    ga_model = ailia.Net(MODEL_GA_PATH, WEIGHT_GA_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         recognize_from_video(args.video, det_model, rec_model, ga_model)

--- a/face_identification/vggface2/vggface2.py
+++ b/face_identification/vggface2/vggface2.py
@@ -100,7 +100,7 @@ def preprocess(img, input_is_bgr=False):
 # ======================
 def compare_images():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     features = []
 
@@ -140,7 +140,7 @@ def compare_images():
 
 def compare_videoframe_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # img part
     fname = args.video[1]

--- a/face_recognition/face_alignment/face_alignment.py
+++ b/face_recognition/face_alignment/face_alignment.py
@@ -324,11 +324,11 @@ def draw_gaussian(img, point, sigma):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     if args.active_3d:
         logger.info('>>> 3D mode is activated!')
         depth_net = ailia.Net(
-            DEPTH_MODEL_PATH, DEPTH_WEIGHT_PATH, env_id=args.env_id
+            DEPTH_MODEL_PATH, DEPTH_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
         )
 
     # input image loop
@@ -398,13 +398,13 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     if args.active_3d:
         logger.info('>>> 3D mode is activated!')
         depth_net = ailia.Net(
-            DEPTH_MODEL_PATH, DEPTH_WEIGHT_PATH, env_id=args.env_id
+            DEPTH_MODEL_PATH, DEPTH_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
         )
-    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_recognition/face_classification/face_classification.py
+++ b/face_recognition/face_classification/face_classification.py
@@ -68,7 +68,7 @@ def recognize_from_image():
     emotion_classifier = ailia.Classifier(
         EMOTION_MODEL_PATH,
         EMOTION_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
@@ -76,7 +76,7 @@ def recognize_from_image():
     gender_classifier = ailia.Classifier(
         GENDER_MODEL_PATH,
         GENDER_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
@@ -148,7 +148,7 @@ def recognize_from_video():
     emotion_classifier = ailia.Classifier(
         EMOTION_MODEL_PATH,
         EMOTION_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
@@ -156,12 +156,12 @@ def recognize_from_video():
     gender_classifier = ailia.Classifier(
         GENDER_MODEL_PATH,
         GENDER_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
     )
-    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_recognition/facemesh/facemesh.py
+++ b/face_recognition/facemesh/facemesh.py
@@ -88,10 +88,10 @@ def draw_landmarks(img, points, color=(0, 0, 255), size=2):
 def recognize_from_image():
     # net initialize
     detector = ailia.Net(
-        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id
+        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     # input image loop
@@ -169,10 +169,10 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     detector = ailia.Net(
-        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id
+        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     capture = get_capture(args.video)

--- a/face_recognition/facial_feature/facial_feature.py
+++ b/face_recognition/facial_feature/facial_feature.py
@@ -69,7 +69,7 @@ def gen_img_from_predsailia(input_data, preds_ailia):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -105,8 +105,8 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
-    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_recognition/gazeml/gazeml.py
+++ b/face_recognition/gazeml/gazeml.py
@@ -87,7 +87,7 @@ def plot_on_image(img, preds_ailia, eye_x, eye_y, eye_w, eye_h):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -136,8 +136,8 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
-    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    detector = ailia.Net(FACE_MODEL_PATH, FACE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/face_recognition/mediapipe_iris/mediapipe_iris.py
+++ b/face_recognition/mediapipe_iris/mediapipe_iris.py
@@ -119,13 +119,13 @@ def draw_eye_iris(
 def recognize_from_image():
     # net initialize
     detector = ailia.Net(
-        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id
+        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator2 = ailia.Net(
-        LANDMARK2_MODEL_PATH, LANDMARK2_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK2_MODEL_PATH, LANDMARK2_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     # prepare input data
@@ -206,13 +206,13 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     detector = ailia.Net(
-        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id
+        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator2 = ailia.Net(
-        LANDMARK2_MODEL_PATH, LANDMARK2_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK2_MODEL_PATH, LANDMARK2_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     capture = get_capture(args.video)

--- a/face_recognition/prnet/prnet.py
+++ b/face_recognition/prnet/prnet.py
@@ -127,7 +127,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 256, 256, 3))
 
     # input image loop
@@ -288,7 +288,7 @@ def recognize_from_image():
 
 def texture_editing_from_images():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 256, 256, 3))
 
     # input image loop
@@ -404,7 +404,7 @@ def recognize_from_video():
     raise NotImplementedError
     """
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = get_capture(args.video)
 

--- a/generative_adversarial_networks/council-GAN/council-gan.py
+++ b/generative_adversarial_networks/council-GAN/council-gan.py
@@ -190,7 +190,7 @@ def replace_face(img, replacement, coords):
 def transform_image():
     """Full transormation on a single image loaded from filepath in arguments.
     """
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -255,7 +255,7 @@ def process_array(net, img):
 
 def process_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.face_recognition:
         locator = FaceLocator()

--- a/generative_adversarial_networks/pytorch-gan/pytorch-gan.py
+++ b/generative_adversarial_networks/pytorch-gan/pytorch-gan.py
@@ -67,7 +67,7 @@ def generate_image():
     rand_input = np.random.rand(1, 512).astype(np.float32)
 
     # net initialize
-    gnet = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    gnet = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # inference
     logger.info('Start inference...')
@@ -99,7 +99,7 @@ def generate_image():
 
 def generate_video():
     # net initialize
-    gnet = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    gnet = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # create video writer if savepath is specified as video format
     if args.savepath != SAVE_IMAGE_PATH:

--- a/hand_detection/blazepalm/blazepalm.py
+++ b/hand_detection/blazepalm/blazepalm.py
@@ -84,7 +84,7 @@ def display_result(img, detections, with_keypoints=True):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -125,7 +125,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/hand_detection/hand_detection_pytorch/hand_detection_pytorch.py
+++ b/hand_detection/hand_detection_pytorch/hand_detection_pytorch.py
@@ -47,7 +47,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     for image_path in args.input:
         # prepare input data
@@ -89,7 +89,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/hand_detection/yolov3-hand/yolov3-hand.py
+++ b/hand_detection/yolov3-hand/yolov3-hand.py
@@ -56,7 +56,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     # input image loop
@@ -96,7 +96,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/hand_recognition/blazehand/blazehand.py
+++ b/hand_recognition/blazehand/blazehand.py
@@ -86,10 +86,10 @@ def draw_landmarks(img, points, connections=[], color=(0, 0, 255), size=2):
 def recognize_from_image():
     # net initialize
     detector = ailia.Net(
-        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id
+        DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id
+        LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     # input image loop
@@ -151,8 +151,8 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    detector = ailia.Net(DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id)
-    estimator = ailia.Net(LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(DETECTION_MODEL_PATH, DETECTION_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    estimator = ailia.Net(LANDMARK_MODEL_PATH, LANDMARK_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     num_hands = args.hands
     thresh = 0.5
     tracking = False

--- a/hand_recognition/hand3d/hand3d.py
+++ b/hand_recognition/hand3d/hand3d.py
@@ -150,7 +150,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/image_captioning/illustration2vec/illustration2vec.py
+++ b/image_captioning/illustration2vec/illustration2vec.py
@@ -125,7 +125,7 @@ def apply_threshold(preds, threshold=0.25, threshold_rule='constant'):
 # ======================
 def recognize_tag_from_image():
     # net initialize
-    tag_net = ailia.Net(TAG_MODEL_PATH, TAG_WEIGHT_PATH, env_id=args.env_id)
+    tag_net = ailia.Net(TAG_MODEL_PATH, TAG_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -165,7 +165,7 @@ def recognize_tag_from_image():
 
 def extract_feature_vec_from_image():
     # net initialize
-    fe_net = ailia.Net(FE_MODEL_PATH, FE_WEIGHT_PATH, env_id=args.env_id)
+    fe_net = ailia.Net(FE_MODEL_PATH, FE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -202,7 +202,7 @@ def extract_feature_vec_from_image():
 
 def recognize_tag_from_video():
     # net initialize
-    tag_net = ailia.Net(TAG_MODEL_PATH, TAG_WEIGHT_PATH, env_id=args.env_id)
+    tag_net = ailia.Net(TAG_MODEL_PATH, TAG_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 
@@ -254,7 +254,7 @@ def recognize_tag_from_video():
 
 def extract_feature_vec_from_video():
     # net initialize
-    fe_net = ailia.Net(FE_MODEL_PATH, FE_WEIGHT_PATH, env_id=args.env_id)
+    fe_net = ailia.Net(FE_MODEL_PATH, FE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_captioning/image_captioning_pytorch/image_captioning_pytorch.py
+++ b/image_captioning/image_captioning_pytorch/image_captioning_pytorch.py
@@ -189,9 +189,9 @@ def main():
     check_and_download_models(WEIGHT_FEAT_PATH, MODEL_FEAT_PATH, REMOTE_PATH)
 
     # initialize
-    net = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    net = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
     my_resnet = ailia.Net(
-        MODEL_FEAT_PATH, WEIGHT_FEAT_PATH, env_id=args.env_id
+        MODEL_FEAT_PATH, WEIGHT_FEAT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     if args.video is not None:

--- a/image_classification/efficientnet/efficientnet.py
+++ b/image_classification/efficientnet/efficientnet.py
@@ -60,7 +60,7 @@ def recognize_from_image():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
     )
@@ -105,7 +105,7 @@ def recognize_from_video():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
     )

--- a/image_classification/googlenet/googlenet.py
+++ b/image_classification/googlenet/googlenet.py
@@ -52,7 +52,7 @@ def recognize_from_image():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )
@@ -97,7 +97,7 @@ def recognize_from_video():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )

--- a/image_classification/inceptionv3/inceptionv3.py
+++ b/image_classification/inceptionv3/inceptionv3.py
@@ -49,7 +49,7 @@ def recognize_from_image():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )
@@ -97,7 +97,7 @@ def recognize_from_video():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )

--- a/image_classification/mobilenetv2/mobilenetv2.py
+++ b/image_classification/mobilenetv2/mobilenetv2.py
@@ -63,7 +63,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/mobilenetv2/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -94,7 +94,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_classification/mobilenetv3/mobilenetv3.py
+++ b/image_classification/mobilenetv3/mobilenetv3.py
@@ -55,7 +55,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/mobilenetv3/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -72,7 +72,7 @@ def recognize_from_image():
         logger.info('Start inference...')
         if args.benchmark:
             logger.info('BENCHMARK mode')
-            for i in range(5):
+            for i in range(args.benchmark_count):
                 start = int(round(time.time() * 1000))
                 preds_ailia = net.predict(input_data)
                 end = int(round(time.time() * 1000))
@@ -86,7 +86,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_classification/partialconv/partialconv.py
+++ b/image_classification/partialconv/partialconv.py
@@ -62,7 +62,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/partialconv/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -94,7 +94,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_classification/resnet50/resnet50.py
+++ b/image_classification/resnet50/resnet50.py
@@ -73,7 +73,7 @@ def recognize_from_image():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=IMAGE_RANGE,
     )
@@ -106,7 +106,7 @@ def recognize_from_video():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_RGB,
         range=IMAGE_RANGE,
     )

--- a/image_classification/vgg16/vgg16.py
+++ b/image_classification/vgg16/vgg16.py
@@ -50,7 +50,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -82,7 +82,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_manipulation/colorization/colorization.py
+++ b/image_manipulation/colorization/colorization.py
@@ -86,7 +86,7 @@ def post_process(out, img_lab_orig):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 1, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     # input image loop
@@ -118,7 +118,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, 1, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     capture = webcamera_utils.get_capture(args.video)

--- a/image_manipulation/dewarpnet/dewarpnet.py
+++ b/image_manipulation/dewarpnet/dewarpnet.py
@@ -93,8 +93,8 @@ def run_inference(wc_net, bm_net, img, org_img):
 
 def unwarp_from_image():
     # net initialize
-    bm_net = ailia.Net(BM_MODEL_PATH, BM_WEIGHT_PATH, env_id=args.env_id)
-    wc_net = ailia.Net(WC_MODEL_PATH, WC_WEIGHT_PATH, env_id=args.env_id)
+    bm_net = ailia.Net(BM_MODEL_PATH, BM_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    wc_net = ailia.Net(WC_MODEL_PATH, WC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -128,8 +128,8 @@ def unwarp_from_image():
 
 def unwarp_from_video():
     # net initialize
-    bm_net = ailia.Net(BM_MODEL_PATH, BM_WEIGHT_PATH, env_id=args.env_id)
-    wc_net = ailia.Net(WC_MODEL_PATH, WC_WEIGHT_PATH, env_id=args.env_id)
+    bm_net = ailia.Net(BM_MODEL_PATH, BM_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    wc_net = ailia.Net(WC_MODEL_PATH, WC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_manipulation/illnet/illnet.py
+++ b/image_manipulation/illnet/illnet.py
@@ -47,7 +47,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -114,7 +114,7 @@ def recognize_from_video():
     logger.warning('This is test implementation')
     # net initialize
 
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_manipulation/inpainting_gmcnn/inpainting_gmcnn.py
+++ b/image_manipulation/inpainting_gmcnn/inpainting_gmcnn.py
@@ -172,7 +172,7 @@ def main():
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
     # net initialize
-    net = ailia.Net(model_path, weight_path, env_id=args.env_id)
+    net = ailia.Net(model_path, weight_path, env_id=args.env_id, debug_log=args.debug)
 
     recognize_from_image(net, img_shape)
 

--- a/image_manipulation/noise2noise/noise2noise.py
+++ b/image_manipulation/noise2noise/noise2noise.py
@@ -61,7 +61,7 @@ def add_noise(img, noise_param=50):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -106,7 +106,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
     # create video writer if savepath is specified as video format

--- a/image_manipulation/pytorch-inpainting-with-partial-conv/pytorch-inpainting-with-partial-conv.py
+++ b/image_manipulation/pytorch-inpainting-with-partial-conv/pytorch-inpainting-with-partial-conv.py
@@ -131,7 +131,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     recognize_from_image(net)
 

--- a/image_manipulation/style2paints/style2paints.py
+++ b/image_manipulation/style2paints/style2paints.py
@@ -344,11 +344,11 @@ def main():
     check_and_download_models(WEIGHT_GIRD_PATH, MODEL_GIRD_PATH, REMOTE_PATH)
 
     # initialize
-    net_head = ailia.Net(MODEL_HEAD_PATH, WEIGHT_HEAD_PATH, env_id=args.env_id)
-    net_neck = ailia.Net(MODEL_NECK_PATH, WEIGHT_NECK_PATH, env_id=args.env_id)
-    net_baby = ailia.Net(MODEL_BABY_PATH, WEIGHT_BABY_PATH, env_id=args.env_id)
-    net_tail = ailia.Net(MODEL_TAIL_PATH, WEIGHT_TAIL_PATH, env_id=args.env_id)
-    net_gird = ailia.Net(MODEL_GIRD_PATH, WEIGHT_GIRD_PATH, env_id=args.env_id)
+    net_head = ailia.Net(MODEL_HEAD_PATH, WEIGHT_HEAD_PATH, env_id=args.env_id, debug_log=args.debug)
+    net_neck = ailia.Net(MODEL_NECK_PATH, WEIGHT_NECK_PATH, env_id=args.env_id, debug_log=args.debug)
+    net_baby = ailia.Net(MODEL_BABY_PATH, WEIGHT_BABY_PATH, env_id=args.env_id, debug_log=args.debug)
+    net_tail = ailia.Net(MODEL_TAIL_PATH, WEIGHT_TAIL_PATH, env_id=args.env_id, debug_log=args.debug)
+    net_gird = ailia.Net(MODEL_GIRD_PATH, WEIGHT_GIRD_PATH, env_id=args.env_id, debug_log=args.debug)
 
     dict_net = {
         "head": net_head,

--- a/image_manipulation/u2net_portrait/u2net_portrait.py
+++ b/image_manipulation/u2net_portrait/u2net_portrait.py
@@ -188,7 +188,7 @@ def post_process(d1):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -221,7 +221,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_segmentation/deep-image-matting/deep-image-matting.py
+++ b/image_segmentation/deep-image-matting/deep-image-matting.py
@@ -262,7 +262,7 @@ def recognize_from_image():
     seg_net = ailia.Net(
         SEGMENTATION_MODEL_PATH,
         SEGMENTATION_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     # input image loop
@@ -320,7 +320,7 @@ def recognize_from_video():
     seg_net = ailia.Net(
         SEGMENTATION_MODEL_PATH,
         SEGMENTATION_WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/image_segmentation/deeplabv3/deeplabv3.py
+++ b/image_segmentation/deeplabv3/deeplabv3.py
@@ -73,7 +73,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/deeplabv3/'
 # ======================
 def segment_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     ailia_input_w = net.get_input_shape()[3]
     ailia_input_h = net.get_input_shape()[2]
     input_shape = [ailia_input_h, ailia_input_w]
@@ -156,7 +156,7 @@ def segment_from_image():
 
 def segment_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     ailia_input_w = net.get_input_shape()[3]
     ailia_input_h = net.get_input_shape()[2]

--- a/image_segmentation/hair_segmentation/hair_segmentation.py
+++ b/image_segmentation/hair_segmentation/hair_segmentation.py
@@ -76,7 +76,7 @@ def transfer(image, mask):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -113,7 +113,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     flag_set_shape = False
 
     capture = webcamera_utils.get_capture(args.video)

--- a/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
+++ b/image_segmentation/hrnet_segmentation/hrnet_segmentation.py
@@ -66,7 +66,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/hrnet/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -106,7 +106,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_segmentation/human_part_segmentation/human_part_segmentation.py
+++ b/image_segmentation/human_part_segmentation/human_part_segmentation.py
@@ -219,7 +219,7 @@ def main():
 
     # Workaround for accuracy issue on
     # ailia SDK 1.2.4 + opset11 + gpu (metal/vulkan)
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/image_segmentation/pspnet-hair-segmentation/pspnet-hair-segmentation.py
+++ b/image_segmentation/pspnet-hair-segmentation/pspnet-hair-segmentation.py
@@ -77,7 +77,7 @@ def postprocess(src_img, preds_ailia):
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -117,7 +117,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_segmentation/pytorch-unet/pytorch-unet.py
+++ b/image_segmentation/pytorch-unet/pytorch-unet.py
@@ -151,7 +151,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # model initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/image_segmentation/semantic-segmentation-mobilenet-v3/semantic-segmentation-mobilenet-v3.py
+++ b/image_segmentation/semantic-segmentation-mobilenet-v3/semantic-segmentation-mobilenet-v3.py
@@ -171,7 +171,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, IMAGE_HEIGHT, IMAGE_WIDTH, 3))
 
     if args.video is not None:

--- a/image_segmentation/u2net/u2net.py
+++ b/image_segmentation/u2net/u2net.py
@@ -67,7 +67,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/u2net/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -113,7 +113,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/image_segmentation/yet-another-anime-segmenter/yet-another-anime-segmenter.py
+++ b/image_segmentation/yet-another-anime-segmenter/yet-another-anime-segmenter.py
@@ -77,7 +77,7 @@ def recognize_from_image():
         import onnxruntime
         sess = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
-        segmentor = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        segmentor = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # inference
     logger.info('Start inference...')
@@ -124,7 +124,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     # This model requires fuge gpu memory so fallback to cpu mode
-    segmentor = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    segmentor = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = get_capture(args.video)
 

--- a/neural_language_processing/bert/bert.py
+++ b/neural_language_processing/bert/bert.py
@@ -156,7 +156,7 @@ def main():
     input_data = [tokens_ts, segments_ts, sentence_id]
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # inference
     logger.info('Start inference...')

--- a/neural_language_processing/bert_maskedlm/bert_maskedlm.py
+++ b/neural_language_processing/bert_maskedlm/bert_maskedlm.py
@@ -86,7 +86,7 @@ def main():
     indexed_tokens = tokenizer.convert_tokens_to_ids(tokenized_text)
     logger.info("Indexed tokens : "+str(indexed_tokens))
 
-    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     indexed_tokens = numpy.array(indexed_tokens)
     token_type_ids = numpy.zeros((1, len(tokenized_text)))

--- a/neural_language_processing/bert_maskedlm/bert_maskedlm_proofreeding.py
+++ b/neural_language_processing/bert_maskedlm/bert_maskedlm_proofreeding.py
@@ -133,7 +133,7 @@ def main():
             "cl-tohoku/"+args.arch
         )
 
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_blob_shape(
         (1, PADDING_LEN), net.find_blob_index_by_name("token_type_ids")
     )

--- a/neural_language_processing/bert_question_answering/bert_question_answering.py
+++ b/neural_language_processing/bert_question_answering/bert_question_answering.py
@@ -228,7 +228,7 @@ def main():
         logger.debug("Input" + str(fw_args))
         logger.debug("Shape" + str(fw_args["input_ids"].shape))
 
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
         net.set_input_shape(fw_args["input_ids"].shape)
         if args.benchmark:
             logger.info('BENCHMARK mode')

--- a/neural_language_processing/bert_sentiment_analysis/bert_sentiment_analysis.py
+++ b/neural_language_processing/bert_sentiment_analysis/bert_sentiment_analysis.py
@@ -49,7 +49,7 @@ def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
-    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     tokenizer = DistilBertTokenizer.from_pretrained(
         'distilbert-base-uncased-finetuned-sst-2-english'
     )

--- a/neural_language_processing/bert_tweets_sentiment/bert_tweets_sentiment.py
+++ b/neural_language_processing/bert_tweets_sentiment/bert_tweets_sentiment.py
@@ -51,7 +51,7 @@ def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
-    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     tokenizer = BertJapaneseTokenizer.from_pretrained(
         'cl-tohoku/bert-base-japanese-whole-word-masking'
     )

--- a/neural_language_processing/bert_zero_shot_classification/bert_zero_shot_classification.py
+++ b/neural_language_processing/bert_zero_shot_classification/bert_zero_shot_classification.py
@@ -70,7 +70,7 @@ def main():
 
     candidate_labels = CANDIDATE_LABELS.split(", ")
 
-    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     tokenizer = AutoTokenizer.from_pretrained('roberta-large-mnli')
 
     model_inputs = preprocess(

--- a/object_detection/centernet/centernet.py
+++ b/object_detection/centernet/centernet.py
@@ -254,7 +254,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # load model
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/object_detection/m2det/m2det.py
+++ b/object_detection/m2det/m2det.py
@@ -262,7 +262,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # load model
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/object_detection/maskrcnn/maskrcnn.py
+++ b/object_detection/maskrcnn/maskrcnn.py
@@ -168,7 +168,7 @@ def display_objdetect_image(
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     if args.profile:
         net.set_profile_mode(True)
 
@@ -208,7 +208,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/object_detection/mobilenet_ssd/mobilenet_ssd.py
+++ b/object_detection/mobilenet_ssd/mobilenet_ssd.py
@@ -87,7 +87,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_SSD,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.profile:
         detector.set_profile_mode(True)
@@ -141,7 +141,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_SSD,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/object_detection/pedestrian_detection/pedestrian_detection.py
+++ b/object_detection/pedestrian_detection/pedestrian_detection.py
@@ -65,7 +65,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.profile:
         detector.set_profile_mode(True)
@@ -113,7 +113,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.detection_width != DETECTION_SIZE or args.detection_height != DETECTION_SIZE:
         detector.set_input_shape(

--- a/object_detection/yolov1-tiny/yolov1-tiny.py
+++ b/object_detection/yolov1-tiny/yolov1-tiny.py
@@ -75,7 +75,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV1,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.profile:
         detector.set_profile_mode(True)
@@ -121,7 +121,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV1,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/object_detection/yolov2/yolov2.py
+++ b/object_detection/yolov2/yolov2.py
@@ -74,7 +74,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV2,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     detector.set_anchors(ANCHORS)
     if args.profile:
@@ -121,7 +121,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_S_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV2,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     detector.set_anchors(ANCHORS)
 

--- a/object_detection/yolov3-tiny/yolov3-tiny.py
+++ b/object_detection/yolov3-tiny/yolov3-tiny.py
@@ -94,7 +94,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.detection_width != DETECTION_SIZE or args.detection_height != DETECTION_SIZE:
         detector.set_input_shape(
@@ -153,7 +153,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.detection_width != DETECTION_SIZE or args.detection_height != DETECTION_SIZE:
         detector.set_input_shape(

--- a/object_detection/yolov3/yolov3.py
+++ b/object_detection/yolov3/yolov3.py
@@ -94,7 +94,7 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.detection_width != DETECTION_SIZE or args.detection_height != DETECTION_SIZE:
         detector.set_input_shape(
@@ -153,7 +153,7 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
     if args.detection_width != DETECTION_SIZE or args.detection_height != DETECTION_SIZE:
         detector.set_input_shape(

--- a/object_detection/yolov4-tiny/yolov4-tiny.py
+++ b/object_detection/yolov4-tiny/yolov4-tiny.py
@@ -246,10 +246,10 @@ def main():
             channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
             range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
             algorithm=ailia.DETECTOR_ALGORITHM_YOLOV4,
-            env_id=args.env_id,
+            env_id=args.env_id, debug_log=args.debug,
         )
     else:
-        detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
         detector.set_input_shape((1, 3, IMAGE_HEIGHT, IMAGE_WIDTH))
 
     if args.video is not None:

--- a/object_detection/yolov4/yolov4.py
+++ b/object_detection/yolov4/yolov4.py
@@ -101,7 +101,7 @@ else:
 # ======================
 def recognize_from_image():
     # net initialize
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     if args.profile:
         detector.set_profile_mode(True)
 
@@ -161,7 +161,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     detector = None
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/object_detection/yolov5/yolov5.py
+++ b/object_detection/yolov5/yolov5.py
@@ -108,7 +108,7 @@ else:
 # ======================
 def recognize_from_image():
     # net initialize
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     if args.profile:
         detector.set_profile_mode(True)
 
@@ -169,7 +169,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     detector = None
-    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    detector = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/object_tracking/deepsort/deepsort.py
+++ b/object_tracking/deepsort/deepsort.py
@@ -106,7 +106,7 @@ def recognize_from_video():
 
     # net initialize
     detector = init_detector(args.env_id)
-    extractor = ailia.Net(EX_MODEL_PATH, EX_WEIGHT_PATH, env_id=args.env_id)
+    extractor = ailia.Net(EX_MODEL_PATH, EX_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # tracker class instance
     metric = NearestNeighborDistanceMetric(
@@ -248,7 +248,7 @@ def compare_images():
 
     # net initialize
     detector = init_detector(args.env_id)
-    extractor = ailia.Net(EX_MODEL_PATH, EX_WEIGHT_PATH, env_id=args.env_id)
+    extractor = ailia.Net(EX_MODEL_PATH, EX_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # prepare input data
     input_data = []

--- a/pose_estimation/3d-pose-baseline/3d-pose-baseline.py
+++ b/pose_estimation/3d-pose-baseline/3d-pose-baseline.py
@@ -426,10 +426,10 @@ def display_result(input_img, pose, baseline):
 def recognize_from_image():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     baseline = ailia.Net(
-        BASELINE_MODEL_PATH, BASELINE_WEIGHT_PATH, env_id=args.env_id
+        BASELINE_MODEL_PATH, BASELINE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     baseline.set_input_shape((1, 32))
 
@@ -475,10 +475,10 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     baseline = ailia.Net(
-        BASELINE_MODEL_PATH, BASELINE_WEIGHT_PATH, env_id=args.env_id
+        BASELINE_MODEL_PATH, BASELINE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     baseline.set_input_shape((1, 32))
 

--- a/pose_estimation/3dmppe_posenet/3dmppe_posenet.py
+++ b/pose_estimation/3dmppe_posenet/3dmppe_posenet.py
@@ -589,11 +589,11 @@ def main():
 
     # net initialize
     # Mask R-CNN
-    net_maskrcnn = ailia.Net(MODEL_PATH_MASKRCNN, WEIGHT_PATH_MASKRCNN, env_id=args.env_id)
+    net_maskrcnn = ailia.Net(MODEL_PATH_MASKRCNN, WEIGHT_PATH_MASKRCNN, env_id=args.env_id, debug_log=args.debug)
     # RootNet
-    net_root = ailia.Net(MODEL_PATH_ROOTNET, WEIGHT_PATH_ROOTNET, env_id=args.env_id)
+    net_root = ailia.Net(MODEL_PATH_ROOTNET, WEIGHT_PATH_ROOTNET, env_id=args.env_id, debug_log=args.debug)
     # PoseNet
-    net_pose = ailia.Net(MODEL_PATH_POSENET, WEIGHT_PATH_POSENET, env_id=args.env_id)
+    net_pose = ailia.Net(MODEL_PATH_POSENET, WEIGHT_PATH_POSENET, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is None:
         # image mode

--- a/pose_estimation/blazepose/blazepose.py
+++ b/pose_estimation/blazepose/blazepose.py
@@ -168,10 +168,10 @@ def display_result(input_img, count, landmarks, flags):
 def recognize_from_image():
     # net initialize
     detector = ailia.Net(
-        DETECTOR_MODEL_PATH, DETECTOR_WEIGHT_PATH, env_id=args.env_id
+        DETECTOR_MODEL_PATH, DETECTOR_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        ESTIMATOR_MODEL_PATH, ESTIMATOR_WEIGHT_PATH, env_id=args.env_id
+        ESTIMATOR_MODEL_PATH, ESTIMATOR_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     # input image loop
@@ -253,10 +253,10 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     detector = ailia.Net(
-        DETECTOR_MODEL_PATH, DETECTOR_WEIGHT_PATH, env_id=args.env_id
+        DETECTOR_MODEL_PATH, DETECTOR_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
     estimator = ailia.Net(
-        ESTIMATOR_MODEL_PATH, ESTIMATOR_WEIGHT_PATH, env_id=args.env_id
+        ESTIMATOR_MODEL_PATH, ESTIMATOR_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug
     )
 
     capture = webcamera_utils.get_capture(args.video)

--- a/pose_estimation/efficientpose/efficientpose.py
+++ b/pose_estimation/efficientpose/efficientpose.py
@@ -146,7 +146,7 @@ def recognize_from_image():
         model = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
         logger.info(f'env_id: {args.env_id}')
-        model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -208,7 +208,7 @@ def recognize_from_video():
         model = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
         logger.info(f'env_id: {args.env_id}')
-        model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = get_capture(args.video)
 

--- a/pose_estimation/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
+++ b/pose_estimation/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
@@ -108,7 +108,7 @@ def main():
     base_width_calculated = False
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # inference
     for frame_id, frame in enumerate(frame_provider):

--- a/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation-analyze.py
+++ b/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation-analyze.py
@@ -78,7 +78,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:

--- a/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation.py
+++ b/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation.py
@@ -142,7 +142,7 @@ def display_result(input_img, pose):
 def recognize_from_image():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     if args.detection_width!=IMAGE_WIDTH or args.detection_height!=IMAGE_HEIGHT:
         pose.set_input_shape((1,3,args.detection_height,args.detection_width))
@@ -189,7 +189,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     if args.detection_width!=IMAGE_WIDTH or args.detection.height!=IMAGE_HEIGHT:
         pose.set_input_shape((1,3,args.detection_height,args.detection_width))

--- a/pose_estimation/openpose/openpose.py
+++ b/pose_estimation/openpose/openpose.py
@@ -140,7 +140,7 @@ def display_result(input_img, pose):
 def recognize_from_image():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     if args.threshold != THRESHOLD_DEFAULT:
         pose.set_threshold(args.threshold)
@@ -182,7 +182,7 @@ def recognize_from_image():
 def recognize_from_video():
     # net initialize
     pose = ailia.PoseEstimator(
-        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, algorithm=ALGORITHM
+        MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, algorithm=ALGORITHM
     )
     if args.threshold != THRESHOLD_DEFAULT:
         pose.set_threshold(args.threshold)

--- a/pose_estimation/pose-hg-3d/pose-hg-3d.py
+++ b/pose_estimation/pose-hg-3d/pose-hg-3d.py
@@ -52,7 +52,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -105,7 +105,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = get_capture(args.video)
 

--- a/pose_estimation/pose_resnet/pose_resnet.py
+++ b/pose_estimation/pose_resnet/pose_resnet.py
@@ -220,10 +220,10 @@ def recognize_from_image():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
-    pose = ailia.Net(POSE_MODEL_PATH, POSE_WEIGHT_PATH, env_id=args.env_id)
+    pose = ailia.Net(POSE_MODEL_PATH, POSE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -269,10 +269,10 @@ def recognize_from_video():
         channel=ailia.NETWORK_IMAGE_CHANNEL_FIRST,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
     )
 
-    pose = ailia.Net(POSE_MODEL_PATH, POSE_WEIGHT_PATH, env_id=args.env_id)
+    pose = ailia.Net(POSE_MODEL_PATH, POSE_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
     # create video writer if savepath is specified as video format

--- a/rotation_prediction/rotnet/rotnet.py
+++ b/rotation_prediction/rotnet/rotnet.py
@@ -64,7 +64,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/rotnet/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -114,7 +114,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
     net.set_input_shape((1, IMAGE_HEIGHT, IMAGE_WIDTH, 3))
 
     capture = webcamera_utils.get_capture(args.video)

--- a/style_transfer/adain/adain.py
+++ b/style_transfer/adain/adain.py
@@ -67,8 +67,8 @@ def style_transfer(vgg, decoder, content, style, alpha=1.0):
 # ======================
 def image_style_transfer():
     # net initialize
-    vgg = ailia.Net(VGG_MODEL_PATH, VGG_WEIGHT_PATH, env_id=args.env_id)
-    decoder = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id)
+    vgg = ailia.Net(VGG_MODEL_PATH, VGG_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    decoder = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -116,8 +116,8 @@ def image_style_transfer():
 
 def video_style_transfer():
     # net initialize
-    vgg = ailia.Net(VGG_MODEL_PATH, VGG_WEIGHT_PATH, env_id=args.env_id)
-    decoder = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id)
+    vgg = ailia.Net(VGG_MODEL_PATH, VGG_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
+    decoder = ailia.Net(DEC_MODEL_PATH, DEC_WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/super_resolution/srresnet/srresnet.py
+++ b/super_resolution/srresnet/srresnet.py
@@ -65,7 +65,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/srresnet/'
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -153,7 +153,7 @@ def tiling(net, img):
 
 def recognize_from_image_tiling():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # processing
     # input image loop
@@ -171,7 +171,7 @@ def recognize_from_image_tiling():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/text_detection/craft_pytorch/craft_pytorch.py
+++ b/text_detection/craft_pytorch/craft_pytorch.py
@@ -47,7 +47,7 @@ args = update_parser(parser)
 # ======================
 def recognize_from_image():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     # input image loop
     for image_path in args.input:
@@ -79,7 +79,7 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/text_detection/east/east.py
+++ b/text_detection/east/east.py
@@ -239,7 +239,7 @@ def main():
 
     # initialize
     memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug, memory_mode=memory_mode)
 
     if args.video is not None:
         recognize_from_video(args.video, net)

--- a/text_recognition/crnn.pytorch/crnn.pytorch.py
+++ b/text_recognition/crnn.pytorch/crnn.pytorch.py
@@ -144,7 +144,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # model initialize
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, debug_log=args.debug)
 
     if args.video is not None:
         # video mode

--- a/text_recognition/deep-text-recognition-benchmark/deep-text-recognition-benchmark.py
+++ b/text_recognition/deep-text-recognition-benchmark/deep-text-recognition-benchmark.py
@@ -86,7 +86,7 @@ def recognize_from_image():
     
     logger.info(f'{dashed_line}\n{head}\n{dashed_line}')
 
-    session = ailia.Net(MODEL_PATH,WEIGHT_PATH,env_id=args.env_id)
+    session = ailia.Net(MODEL_PATH,WEIGHT_PATH,env_id=args.env_id, debug_log=args.debug)
 
     print(args.input)
 

--- a/text_recognition/etl/etl.py
+++ b/text_recognition/etl/etl.py
@@ -60,7 +60,7 @@ def recognize_from_image():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )
@@ -105,7 +105,7 @@ def recognize_from_video():
     classifier = ailia.Classifier(
         MODEL_PATH,
         WEIGHT_PATH,
-        env_id=args.env_id,
+        env_id=args.env_id, debug_log=args.debug,
         format=ailia.NETWORK_IMAGE_FORMAT_GRAY,
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
     )


### PR DESCRIPTION
https://github.com/axell-corp/ailia/issues/1795

有効にしたときの出力例
```
 INFO mobilenetv3.py (79) :     ailia processing time 10 ms
Traceback (most recent call last):
  File ".\mobilenetv3.py", line 146, in <module>
    main()
  File ".\mobilenetv3.py", line 142, in main
    recognize_from_image()
  File ".\mobilenetv3.py", line 77, in recognize_from_image
    preds_ailia = net.predict(input_data)
  File "D:\work\ax-models\image_classification\mobilenetv3\ailia\wrapper.py", line 340, in predict
    self.update()
  File "D:\work\ax-models\image_classification\mobilenetv3\ailia\wrapper.py", line 655, in update
    core.check_error(code, self.__net)
  File "D:\work\ax-models\image_classification\mobilenetv3\ailia\core.py", line 660, in check_error
    raise e(detail)
ailia.core.AiliaGpuErrorException: code : -14
+ error detail : ErrorCode:-14(gpu internal error.)
Last Called API:ailiaUpdate
==ErrorDetail==
Layer:245(Convolution) Error:Cuda failure(unknown error)
==ENV==
 name:cuDNN-GeForce MX150 (6.1, FP32)
 type:2
 backend:2
 prors:0x0
==GRAPH==
 in<0> blob_index:0 name:input.1 shape:(1,3,224,224)
 out<0> blob_index:666 name:700 shape:(1,1000)
==APILog==
 API:ailiaOpenStreamFileW
 API:ailiaOpenStreamEx(fopen_args:0x159fcdce2b0)
 API:ailiaOpenWeightFileW
 API:ailiaOpenWeightEx(fopen_args:0x159fcc351e0 callback_version:1)
 API:ailiaGetInputBlobCount(input_blob_count:0x159fcd68910)
  input_blob_count:1
 API:ailiaGetBlobIndexByInputIndex(blob_idx:0x159fcd68990 input_blob_idx:0)
  blob_idx:0
 API:ailiaGetBlobDim(dim:0x159fcd68990 blob_idx:0)
  dim:00000159FCD68990
 API:ailiaGetBlobShapeND(shape:0x159fc432ac0 dim:4 blob_idx:0)
  blob_shape:(1,3,224,224)
 API:ailiaSetInputBlobData(src:0x15a00b760c0 src_size:602112 blob_idx:0)
 API:ailiaUpdate
 API:ailiaGetOutputBlobCount(output_blob_count:0x159fcd68990)
  output_blob_count:1
 API:ailiaGetBlobIndexByOutputIndex(blob_idx:0x159fcd68a90 output_blob_idx:0)
  blob_idx:666
```