### PR TITLE
Improve yolov3 performance

### DIFF
--- a/object_detection/yolov3/README.md
+++ b/object_detection/yolov3/README.md
@@ -52,4 +52,4 @@ ONNX opset=10
 
 ## Netron
 
-[yolov3.opt.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/yolov3/yolov3.opt.onnx.prototxt)
+[yolov3.opt2.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/yolov3/yolov3.opt2.onnx.prototxt)

--- a/object_detection/yolov3/yolov3.py
+++ b/object_detection/yolov3/yolov3.py
@@ -22,8 +22,8 @@ logger = getLogger(__name__)
 # ======================
 # Parameters
 # ======================
-WEIGHT_PATH = 'yolov3.opt.onnx'
-MODEL_PATH = 'yolov3.opt.onnx.prototxt'
+WEIGHT_PATH = 'yolov3.opt2.onnx'
+MODEL_PATH = 'yolov3.opt2.onnx.prototxt'
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/yolov3/'
 
 IMAGE_PATH = 'input.jpg'


### PR DESCRIPTION
従来のonnx
producer_name: “keras2onnx+onnx_optimizer”
producer_version: “1.4.1+0.3"
INFO yolov3.py (125) : 	average time 195.0 ms

今回のonnx
producer_name: “keras2onnx+onnx_optimizer”
producer_version: “1.5.1+0.8"
INFO yolov3.py (125) : 	average time 183.5 ms

Test on MacBook Pro 13