### PR TITLE
Fix psgan video mode

### DIFF
--- a/style_transfer/psgan/README.md
+++ b/style_transfer/psgan/README.md
@@ -37,6 +37,8 @@ If you pass `0` as an argument to VIDEO_PATH, you can use the webcam input inste
 $ python3 psgan.py --video VIDEO_PATH --style STYLE_IMAGE_PATH
 ```
 
+By adding the `--use_dlib` option, you can use original version of face and landmark detection.
+
 ### Reference
 
 [PSGAN : Pose and Expression Robust Spatial-Aware GAN for Customizable Makeup Transfer](https://github.com/wtjiang98/PSGAN)

--- a/style_transfer/psgan/psgan.py
+++ b/style_transfer/psgan/psgan.py
@@ -130,14 +130,7 @@ def _initialize_net(args):
 
 def _transfer(real_A, real_B, mask_A, mask_B, diff_A, diff_B, net):
     if not args.onnx:
-        return net.predict(
-            [real_A,
-            real_B,
-            mask_A,
-            mask_B,
-            diff_A,
-            diff_B]
-        )
+        return net.predict([real_A, real_B, mask_A, mask_B, diff_A, diff_B])
     else:
         inputs = {
             net.get_inputs()[0].name: real_A,

--- a/style_transfer/psgan/psgan/postprocess.py
+++ b/style_transfer/psgan/psgan/postprocess.py
@@ -15,11 +15,16 @@ class PostProcess:
 
         height, width = source.shape[:2]
         small_source = cv2.resize(source, (self.img_size, self.img_size))
-        laplacian_diff = source.astype(
-            np.float) - cv2.resize(small_source, (width, height)).astype(np.float)
-        result = (cv2.resize(result, (width, height)) +
-                  laplacian_diff).round().clip(0, 255).astype(np.uint8)
+        laplacian_diff = source.astype(np.float) - cv2.resize(
+            small_source, (width, height)
+        ).astype(np.float)
+        result = (
+            (cv2.resize(result, (width, height)) + laplacian_diff)
+            .round()
+            .clip(0, 255)
+            .astype(np.uint8)
+        )
         if self.denoise:
             result = cv2.fastNlMeansDenoisingColored(result)
-        result = Image.fromarray(result).convert('RGB')
+        result = Image.fromarray(result).convert("RGB")
         return result

--- a/style_transfer/psgan/psgan/preprocess.py
+++ b/style_transfer/psgan/psgan/preprocess.py
@@ -174,20 +174,7 @@ class PreProcess:
             )
             lms = lms.round()
         else:
-            image_numpy = np.array(image)
-
-            if face[0]<0:
-                face[0]=0
-            if face[1]<0:
-                face[1]=0
-            if face[2]>image_numpy.shape[0]:
-                face[2]=image_numpy.shape[0]
-            if face[3]>image_numpy.shape[1]:
-                face[3]=image_numpy.shape[1]
-
-            face_image = image_numpy[face[1]:face[3],face[0]:face[2],:]
-
-            data = np.array(face_image)
+            data = np.array(image)
             data=cv2.resize(data,(FACE_ALIGNMENT_IMAGE_WIDTH,FACE_ALIGNMENT_IMAGE_HEIGHT))
             data=data / 255.0
             data = data.transpose((2, 0, 1))  # channel first

--- a/style_transfer/psgan/psgan/preprocess.py
+++ b/style_transfer/psgan/psgan/preprocess.py
@@ -88,7 +88,7 @@ class FaceDetector:
             data=cv2.resize(data,(FACE_DETECTOR_IMAGE_WIDTH,FACE_DETECTOR_IMAGE_HEIGHT))
             data=data / 127.5 - 1.0
             data = data.transpose((2, 0, 1))  # channel first
-            data = data[np.newaxis, :, :, :]  # (batch_size, channel, h, w)
+            data = data[np.newaxis, :, :, :].astype(np.float32)  # (batch_size, channel, h, w)
         else:
             data = load_image(
                 self.input,
@@ -178,7 +178,7 @@ class PreProcess:
             data=cv2.resize(data,(FACE_ALIGNMENT_IMAGE_WIDTH,FACE_ALIGNMENT_IMAGE_HEIGHT))
             data=data / 255.0
             data = data.transpose((2, 0, 1))  # channel first
-            data = data[np.newaxis, :, :, :]  # (batch_size, channel, h, w)
+            data = data[np.newaxis, :, :, :].astype(np.float32)  # (batch_size, channel, h, w)
 
             preds_ailia = self.face_alignment.predict(data)
             pts, _ = _get_preds_from_hm(preds_ailia)

--- a/style_transfer/psgan/psgan/preprocess.py
+++ b/style_transfer/psgan/psgan/preprocess.py
@@ -67,7 +67,9 @@ class FaceAlignment:
 
 
 class FaceDetector:
-    def __init__(self, use_onnx, face_detector_model, face_detector_weight, input, env_id):
+    def __init__(
+        self, use_onnx, face_detector_model, face_detector_weight, input, env_id
+    ):
         self.face_detector_model = face_detector_model
         self.face_detector_weight = face_detector_weight
         self.use_onnx = use_onnx
@@ -83,12 +85,16 @@ class FaceDetector:
             self.net = onnxruntime.InferenceSession(self.face_detector_weight)
 
     def predict(self, image: Image):
-        if self.input==None:
+        if self.input == None:
             data = np.array(image)
-            data=cv2.resize(data,(FACE_DETECTOR_IMAGE_WIDTH,FACE_DETECTOR_IMAGE_HEIGHT))
-            data=data / 127.5 - 1.0
+            data = cv2.resize(
+                data, (FACE_DETECTOR_IMAGE_WIDTH, FACE_DETECTOR_IMAGE_HEIGHT)
+            )
+            data = data / 127.5 - 1.0
             data = data.transpose((2, 0, 1))  # channel first
-            data = data[np.newaxis, :, :, :].astype(np.float32)  # (batch_size, channel, h, w)
+            data = data[np.newaxis, :, :, :].astype(
+                np.float32
+            )  # (batch_size, channel, h, w)
         else:
             data = load_image(
                 self.input,
@@ -149,14 +155,21 @@ class PreProcess:
         self.use_dlib = args.use_dlib
         if not self.use_dlib:
             if not args.input:
-                self.input = None   # video mode
+                self.input = None  # video mode
             else:
                 self.input = args.input[0]
             self.face_alignment = FaceAlignment(
-                self.use_onnx, face_alignment_path[0], face_alignment_path[1], args.env_id
+                self.use_onnx,
+                face_alignment_path[0],
+                face_alignment_path[1],
+                args.env_id,
             )
             self.face_detector = FaceDetector(
-                self.use_onnx, face_detector_path[0], face_detector_path[1], self.input, args.env_id
+                self.use_onnx,
+                face_detector_path[0],
+                face_detector_path[1],
+                self.input,
+                args.env_id,
             )
 
     def relative2absolute(self, lms):
@@ -175,10 +188,14 @@ class PreProcess:
             lms = lms.round()
         else:
             data = np.array(image)
-            data=cv2.resize(data,(FACE_ALIGNMENT_IMAGE_WIDTH,FACE_ALIGNMENT_IMAGE_HEIGHT))
-            data=data / 255.0
+            data = cv2.resize(
+                data, (FACE_ALIGNMENT_IMAGE_WIDTH, FACE_ALIGNMENT_IMAGE_HEIGHT)
+            )
+            data = data / 255.0
             data = data.transpose((2, 0, 1))  # channel first
-            data = data[np.newaxis, :, :, :].astype(np.float32)  # (batch_size, channel, h, w)
+            data = data[np.newaxis, :, :, :].astype(
+                np.float32
+            )  # (batch_size, channel, h, w)
 
             preds_ailia = self.face_alignment.predict(data)
             pts, _ = _get_preds_from_hm(preds_ailia)


### PR DESCRIPTION
psganをdlibを使用せずにvideoモードで実行した場合に、うまく顔を認識できない問題の修正です。

・dlibを使用しない場合に、webcamのimageではなく、静止画に対して顔認識していた問題を修正
・dlibを使用しない場合に、認識した顔ではなく、画面全体に対してランドマーク認識していた問題を修正