### PR TITLE
Fix launcher not worked on macos

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -134,8 +134,7 @@ def open_model(model):
     
     cmd = [cmd, model["model"]+".py"] + options
     print(" ".join(cmd))
-    
-    subprocess.check_call(cmd, cwd=dir, shell=True)
+    subprocess.check_call(cmd, cwd=dir, shell=False)
 
 
 def display_loading(img, model):


### PR DESCRIPTION
macOSでlauncher.pyからコマンドが呼び出せない問題を修正するPRです。shell=Trueの場合、引数はlistではなくstrで与える必要があるようなので、shell=Falseとしました。
#751 