### PR TITLE
Detic for ONNXRuntime

### DIFF
--- a/object_detection/detic/detic.py
+++ b/object_detection/detic/detic.py
@@ -340,7 +340,7 @@ def predict(net, img):
     im_h, im_w = img.shape[:2]
     img = preprocess(img)
     pred_hw = img.shape[-2:]
-    im_hw = np.array([im_h, im_w])
+    im_hw = np.array([im_h, im_w]).astype(np.int64)
 
     # feedforward
     if args.opset16:

--- a/object_detection/detic/detic.py
+++ b/object_detection/detic/detic.py
@@ -341,6 +341,7 @@ def predict(net, img):
     img = preprocess(img)
     pred_hw = img.shape[-2:]
     im_hw = np.array([im_h, im_w]).astype(np.int64)
+    #img[:] = 0 # test for grid sampler
 
     # feedforward
     if args.opset16:


### PR DESCRIPTION
Deticのhwの型がint64のところをfloatを渡しているために、ONNXRuntimeで動作しない問題を修正。
#904 