### PR TITLE
use encoding='utf-8' parameter with open()

### DIFF
--- a/audio_processing/whisper/ailia_tokenizer.py
+++ b/audio_processing/whisper/ailia_tokenizer.py
@@ -51,7 +51,7 @@ class AiliaTokenizer:
         self.language = language
 
         # load vocab
-        json_open = open(vocab_path, 'r')
+        json_open = open(vocab_path, 'r', encoding='utf-8')
         json_load = json.load(json_open)
         for key in json_load.keys():
             self.vocab[json_load[key]] = key


### PR DESCRIPTION
workaround for windows(japanese) environment.

before :
```
C:\src\ailia-models\audio_processing\whisper>python whisper.py -e 0
 INFO utils.py (13) : Start!
 INFO utils.py (163) : env_id: 0
 INFO utils.py (166) : CPU
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO whisper.py (839) : This model uses a lot of memory. If an error occurs during execution, specify -e 0 and execute on the CPU.
 INFO whisper.py (733) : demo.wav
 INFO whisper.py (739) : Start inference...
Traceback (most recent call last):
  File "C:\src\ailia-models\audio_processing\whisper\whisper.py", line 871, in <module>
    main()
  File "C:\src\ailia-models\audio_processing\whisper\whisper.py", line 861, in main
    recognize_from_audio(enc_net, dec_net)
  File "C:\src\ailia-models\audio_processing\whisper\whisper.py", line 756, in recognize_from_audio
    output = predict(wav, enc_net, dec_net, immediate=immediate)
  File "C:\src\ailia-models\audio_processing\whisper\whisper.py", line 601, in predict
    _, probs = detect_language(enc_net, dec_net, segment)
  File "C:\src\ailia-models\audio_processing\whisper\whisper.py", line 363, in detect_language
    tokenizer = get_tokenizer(is_multilingual())
  File "C:\src\ailia-models\audio_processing\whisper\ailia_tokenizer.py", line 23, in get_tokenizer
    tokenizer.build_tokenizer('assets/multilingual/vocab.json', tokenizer_name, task, language)
  File "C:\src\ailia-models\audio_processing\whisper\ailia_tokenizer.py", line 55, in build_tokenizer
    json_load = json.load(json_open)
  File "C:\opt\Python39\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
UnicodeDecodeError: 'cp932' codec can't decode byte 0x81 in position 1176: illegal multibyte sequence
```

after :
```
python whisper.py -e 0
 INFO utils.py (13) : Start!
 INFO utils.py (163) : env_id: 0
 INFO utils.py (166) : CPU
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO whisper.py (839) : This model uses a lot of memory. If an error occurs during execution, specify -e 0 and execute on the CPU.
 INFO whisper.py (733) : demo.wav
 INFO whisper.py (739) : Start inference...
 INFO whisper.py (603) : Detected language: English
 INFO whisper.py (637) : [00:00.000 --> 00:10.000]  He hoped there would be stew for dinner, turnips and carrots and bruised potatoes and fat mutton pieces to be ladled out in thick, peppered, flour-fattened sauce.
 INFO whisper.py (763) : Script finished successfully.
```