### PR TITLE
Update numpy aliases

### DIFF
--- a/action_recognition/ax_action_recognition/ax_action_recognition.py
+++ b/action_recognition/ax_action_recognition/ax_action_recognition.py
@@ -457,7 +457,7 @@ def recognize_from_video():
             box = track.to_tlwh()
             x1, y1, x2, y2 = tlwh_to_xyxy(box, h, w)
             track_id = track.track_id
-            outputs.append(np.array([x1, y1, x2, y2, track_id], dtype=np.int))
+            outputs.append(np.array([x1, y1, x2, y2, track_id], dtype=int))
         if len(outputs) > 0:
             outputs = np.stack(outputs, axis=0)
 

--- a/background_removal/deep-image-matting/deep_image_matting_util.py
+++ b/background_removal/deep-image-matting/deep_image_matting_util.py
@@ -126,7 +126,7 @@ def dump_segmentation_threshold(trimap_data, src_data, w, h, args):
     savedir = os.path.dirname(args.savepath)
     segmentation_data = trimap_data.copy()
     segmentation_data = cv2.cvtColor(segmentation_data, cv2.COLOR_GRAY2BGR)
-    segmentation_data = segmentation_data.astype(np.float)
+    segmentation_data = segmentation_data.astype(float)
     segmentation_data = (src_data + segmentation_data)/2
     cv2.imwrite(
         os.path.join(savedir, "debug_segmentation_threshold.png"),
@@ -144,7 +144,7 @@ def dump_trimap(trimap_data, src_data, w, h, args):
 
     segmentation_data = trimap_data.copy().astype(np.uint8)
     segmentation_data = cv2.cvtColor(segmentation_data, cv2.COLOR_GRAY2BGR)
-    segmentation_data = segmentation_data.astype(np.float)
+    segmentation_data = segmentation_data.astype(float)
     segmentation_data = (src_data + segmentation_data)/2
 
     cv2.imwrite(

--- a/deep_fashion/clothing-detection/clothing-detection.py
+++ b/deep_fashion/clothing-detection/clothing-detection.py
@@ -106,7 +106,7 @@ def preprocess(img, resize):
 
 
 def post_processing(img_shape, all_boxes, all_scores, indices):
-    indices = indices.astype(np.int)
+    indices = indices.astype(int)
 
     bboxes = []
     for idx_ in indices[0]:

--- a/deep_fashion/mmfashion_tryon/mmfashion_tryon_utils.py
+++ b/deep_fashion/mmfashion_tryon/mmfashion_tryon_utils.py
@@ -81,10 +81,10 @@ def grid_sample(image, grid, padding_mode='zeros', align_corners=False):
                 # Get values of the image by provided x0,y0,x1,y1 by channel
                 for c in range(C):
                     # image, n, c, x, y, H, W
-                    x0 = x0.astype(np.int)
-                    y0 = y0.astype(np.int)
-                    x1 = x1.astype(np.int)
-                    y1 = y1.astype(np.int)
+                    x0 = x0.astype(int)
+                    y0 = y0.astype(int)
+                    x1 = x1.astype(int)
+                    y1 = y1.astype(int)
                     Ia = safe_get(image, n, c, x0, y0, H, W, padding_mode)
                     Ib = safe_get(image, n, c, x0, y1, H, W, padding_mode)
                     Ic = safe_get(image, n, c, x1, y0, H, W, padding_mode)

--- a/face_detection/dbface/dbface_utils.py
+++ b/face_detection/dbface/dbface_utils.py
@@ -350,7 +350,7 @@ def max_pool2d(A, kernel_size, stride, padding):
 
 
 def get_topk_score_indices(hm_pool, hm, k):
-    ary = ((hm_pool == hm).astype(np.bool) * hm).reshape(-1)
+    ary = ((hm_pool == hm).astype(bool) * hm).reshape(-1)
     indices = ary.argsort()[::-1][:k]
     scores = ary[indices]
     return scores, indices

--- a/face_identification/vggface2/vggface2.py
+++ b/face_identification/vggface2/vggface2.py
@@ -89,7 +89,7 @@ def preprocess(img, input_is_bgr=False):
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
 
     # normalize image
-    input_data = (img.astype(np.float) - MEAN)
+    input_data = (img.astype(float) - MEAN)
     input_data = input_data.transpose((2, 0, 1))
     input_data = input_data[np.newaxis, :, :, :]
     return input_data

--- a/face_recognition/face_alignment/face_alignment.py
+++ b/face_recognition/face_alignment/face_alignment.py
@@ -201,7 +201,7 @@ def transform(point, center, scale, resolution, invert=False):
     if invert:
         t = np.linalg.inv(t)
     new_point = (np.dot(t, _pt))[0:2]
-    return new_point.astype(np.int)
+    return new_point.astype(int)
 
 
 def get_preds_from_hm(hm):
@@ -226,7 +226,7 @@ def get_preds_from_hm(hm):
     )
     idx += 1
     preds = idx.reshape(idx.shape[0], idx.shape[1], 1)
-    preds = np.tile(preds, (1, 1, 2)).astype(np.float)
+    preds = np.tile(preds, (1, 1, 2)).astype(float)
     preds[..., 0] = (preds[..., 0] - 1) % hm.shape[3] + 1
     preds[..., 1] = np.floor((preds[..., 1] - 1) / (hm.shape[2])) + 1
 
@@ -237,7 +237,7 @@ def get_preds_from_hm(hm):
             if pX > 0 and pX < 63 and pY > 0 and pY < 63:
                 diff = np.array(
                     [hm_[pY, pX + 1] - hm_[pY, pX - 1],
-                     hm_[pY + 1, pX] - hm_[pY - 1, pX]]).astype(np.float)
+                     hm_[pY + 1, pX] - hm_[pY - 1, pX]]).astype(float)
                 preds[i, j] = preds[i, j] + (np.sign(diff) * 0.25)
 
     preds += -0.5

--- a/face_recognition/prnet/prnet_utils/cv_plot.py
+++ b/face_recognition/prnet/prnet_utils/cv_plot.py
@@ -54,7 +54,7 @@ def plot_pose_box(image, P, kpt, color=(0, 255, 0), line_width=2):
     point_3d.append((front_size, front_size, front_depth))
     point_3d.append((front_size, -front_size, front_depth))
     point_3d.append((-front_size, -front_size, front_depth))
-    point_3d = np.array(point_3d, dtype=np.float).reshape(-1, 3)
+    point_3d = np.array(point_3d, dtype=float).reshape(-1, 3)
 
     # Map to 2d image points
     point_3d_homo = np.hstack((point_3d, np.ones([point_3d.shape[0],1]))) #n x 4

--- a/image_inpainting/3d-photo-inpainting/trid_photo_inpainting_utils.py
+++ b/image_inpainting/3d-photo-inpainting/trid_photo_inpainting_utils.py
@@ -134,11 +134,11 @@ def filter_irrelevant_edge_new(
                                         np.array([[1, 1, 1], [1, 1, 1], [1, 1, 1]]), iterations=1)
     dilate_cross_self_edge = cv2.dilate((self_edge + comp_edge).astype(np.uint8),
                                         np.array([[0, 1, 0], [1, 1, 1], [0, 1, 0]]).astype(np.uint8), iterations=1)
-    edge_ids = np.unique(other_edges_with_id * context + (-1) * (1 - context)).astype(np.int)
+    edge_ids = np.unique(other_edges_with_id * context + (-1) * (1 - context)).astype(int)
     end_depth_maps = np.zeros_like(self_edge)
-    self_edge_ids = np.sort(np.unique(other_edges_with_id[self_edge > 0]).astype(np.int))
+    self_edge_ids = np.sort(np.unique(other_edges_with_id[self_edge > 0]).astype(int))
     self_edge_ids = self_edge_ids[1:] if self_edge_ids.shape[0] > 0 and self_edge_ids[0] == -1 else self_edge_ids
-    self_comp_ids = np.sort(np.unique(other_edges_with_id[comp_edge > 0]).astype(np.int))
+    self_comp_ids = np.sort(np.unique(other_edges_with_id[comp_edge > 0]).astype(int))
     self_comp_ids = self_comp_ids[1:] if self_comp_ids.shape[0] > 0 and self_comp_ids[0] == -1 else self_comp_ids
     edge_ids = edge_ids[1:] if edge_ids[0] == -1 else edge_ids
     other_edges_info = []
@@ -822,8 +822,8 @@ def refine_color_around_edge(
     for edge_id, edge_cc in enumerate(edge_ccs):
         if len(edge_cc) == 0:
             continue
-        near_maps = np.zeros((H, W)).astype(np.bool)
-        far_maps = np.zeros((H, W)).astype(np.bool)
+        near_maps = np.zeros((H, W)).astype(bool)
+        far_maps = np.zeros((H, W)).astype(bool)
         tmp_far_nodes = set()
         far_nodes = set()
         near_nodes = set()
@@ -1439,7 +1439,7 @@ def extrapolate(
     edge_output = edge_forward_3P(
         depth_edge_model, t_mask, t_context, t_rgb, t_disp, t_edge)
 
-    output_raw_edge = (edge_output > config['ext_edge_threshold']).astype(np.float) * t_mask + t_edge
+    output_raw_edge = (edge_output > config['ext_edge_threshold']).astype(float) * t_mask + t_edge
     output_raw_edge = output_raw_edge.squeeze()
 
     mesh = netx.Graph()
@@ -1644,9 +1644,9 @@ def extrapolate(
     fpath_ids = fpath_ids[1:] if fpath_ids.shape[0] > 0 and fpath_ids[0] == -1 else []
     fpath_real_id_map = np.zeros_like(global_fpath_map) - 1
     for fpath_id in fpath_ids:
-        fpath_real_id = np.unique(((global_fpath_map == fpath_id).astype(np.int) * (other_edge_with_id + 1)) - 1)
+        fpath_real_id = np.unique(((global_fpath_map == fpath_id).astype(int) * (other_edge_with_id + 1)) - 1)
         fpath_real_id = fpath_real_id[1:] if fpath_real_id.shape[0] > 0 and fpath_real_id[0] == -1 else []
-        fpath_real_id = fpath_real_id.astype(np.int)
+        fpath_real_id = fpath_real_id.astype(int)
         fpath_real_id = np.bincount(fpath_real_id).argmax()
         fpath_real_id_map[global_fpath_map == fpath_id] = fpath_real_id
     nxs, nys = np.where((fpath_map > -1))
@@ -2379,7 +2379,7 @@ def reassign_floating_island(mesh, info_on_pix, image, depth):
     _, label_lost_map = cv2.connectedComponents(lost_map.astype(np.uint8), connectivity=4)
     mask = np.zeros((H, W))
     mask[bord_up:bord_down, bord_left:bord_right] = 1
-    label_lost_map = (label_lost_map * mask).astype(np.int)
+    label_lost_map = (label_lost_map * mask).astype(int)
 
     for i in range(1, label_lost_map.max() + 1):
         lost_xs, lost_ys = np.where(label_lost_map == i)
@@ -3090,8 +3090,8 @@ def context_and_holes(
     forbidden_len = 3
     forbidden_map = np.ones((mesh.graph['H'] - forbidden_len, mesh.graph['W'] - forbidden_len))
     forbidden_map = np.pad(forbidden_map, ((forbidden_len, forbidden_len), (forbidden_len, forbidden_len)),
-                           mode='constant').astype(np.bool)
-    cur_tmp_mask_map = np.zeros_like(forbidden_map).astype(np.bool)
+                           mode='constant').astype(bool)
+    cur_tmp_mask_map = np.zeros_like(forbidden_map).astype(bool)
     passive_background = 10 if 10 is not None else background_thickness
     passive_context = 1 if 1 is not None else context_thickness
 
@@ -3110,7 +3110,7 @@ def context_and_holes(
                 tmp_mask_nodes = copy.deepcopy(mask_ccs[edge_id])
                 tmp_intersect_nodes = []
                 tmp_intersect_context_nodes = []
-                mask_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
+                mask_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
                 context_depth = np.zeros((mesh.graph['H'], mesh.graph['W']))
                 comp_cnt_depth = np.zeros((mesh.graph['H'], mesh.graph['W']))
                 connect_map = np.zeros((mesh.graph['H'], mesh.graph['W']))
@@ -3137,20 +3137,20 @@ def context_and_holes(
                                 connect_map[xx[0], xx[1]] = xx[2]
                 tmp_context_nodes = [*context_ccs[edge_id]]
                 tmp_erode.append([*context_ccs[edge_id]])
-                context_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
+                context_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
                 for node in tmp_context_nodes:
                     context_map[node[0], node[1]] = True
                     context_depth[node[0], node[1]] = node[2]
                 context_map[mask_map == True] = False
                 tmp_intouched_nodes = [*intouched_ccs[edge_id]]
-                intouched_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
+                intouched_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
                 for node in tmp_intouched_nodes: intouched_map[node[0], node[1]] = True
                 intouched_map[mask_map == True] = False
                 tmp_redundant_nodes = set()
                 tmp_noncont_nodes = set()
-                noncont_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
-                intersect_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
-                intersect_context_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=np.bool)
+                noncont_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
+                intersect_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
+                intersect_context_map = np.zeros((mesh.graph['H'], mesh.graph['W']), dtype=bool)
             if i > passive_background and inpaint_iter == 0:
                 new_tmp_intersect_nodes = None
                 new_tmp_intersect_nodes = []
@@ -3448,9 +3448,9 @@ def context_and_holes(
                     tmp_context_nodes = copy.deepcopy(ecnt_cc)
                     tmp_invalid_context_nodes = copy.deepcopy(invalid_extend_edge_ccs[ecnt_id])
                     tmp_mask_nodes = copy.deepcopy(accomp_extend_context_ccs[ecnt_id])
-                    tmp_context_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(np.bool)
-                    tmp_mask_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(np.bool)
-                    tmp_invalid_context_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(np.bool)
+                    tmp_context_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(bool)
+                    tmp_mask_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(bool)
+                    tmp_invalid_context_map = np.zeros((mesh.graph['H'], mesh.graph['W'])).astype(bool)
                     for node in tmp_mask_nodes:
                         tmp_mask_map[node[0], node[1]] = True
                     for node in context_ccs[ecnt_id]:
@@ -3622,7 +3622,7 @@ def DL_inpaint_edge(
                 tensor_edge_dict['edge'])
 
             tensor_edge_dict['output'] = \
-                (depth_edge_output > config['ext_edge_threshold']).astype(np.float) \
+                (depth_edge_output > config['ext_edge_threshold']).astype(float) \
                 * tensor_edge_dict['mask'] + tensor_edge_dict['edge']
         else:
             tensor_edge_dict['output'] = tensor_edge_dict['edge']
@@ -3632,7 +3632,7 @@ def DL_inpaint_edge(
         edge_dict['output'][union_size['x_min']:union_size['x_max'], union_size['y_min']:union_size['y_max']] = \
             patch_edge_dict['output']
         if require_depth_edge(patch_edge_dict['edge'], patch_edge_dict['mask']) and inpaint_iter == 0:
-            if ((depth_edge_output > config['ext_edge_threshold']).astype(np.float) * tensor_edge_dict[
+            if ((depth_edge_output > config['ext_edge_threshold']).astype(float) * tensor_edge_dict[
                 'mask']).max() > 0:
                 try:
                     edge_dict['fpath_map'], edge_dict['npath_map'], break_flag, npaths, fpaths, invalid_edge_id = \
@@ -3654,7 +3654,7 @@ def DL_inpaint_edge(
                             tensor_input_edge)
 
                         depth_edge_output = \
-                            (depth_edge_output > config['ext_edge_threshold']).astype(np.float) * \
+                            (depth_edge_output > config['ext_edge_threshold']).astype(float) * \
                             tensor_edge_dict['mask'] + tensor_edge_dict['edge']
                         depth_edge_output = depth_edge_output.squeeze()
                         full_depth_edge_output = np.zeros((mesh.graph['H'], mesh.graph['W']))
@@ -3852,8 +3852,8 @@ def DL_inpaint_edge(
                 None,
                 fx=frac, fy=frac,
                 interpolation=cv2.INTER_AREA).transpose(2, 0, 1)[None, :]
-            resize_rgb_dict['mask'] = (resize_mark[:, 0:1] > 0).astype(np.float)
-            resize_rgb_dict['context'] = (np.abs(resize_mark[:, 1:2]-1) < 0.1).astype(np.float)
+            resize_rgb_dict['mask'] = (resize_mark[:, 0:1] > 0).astype(float)
+            resize_rgb_dict['context'] = (np.abs(resize_mark[:, 1:2]-1) < 0.1).astype(float)
             resize_rgb_dict['context'][resize_rgb_dict['mask'] > 0] = 0
             resize_rgb_dict['rgb'] = cv2.resize(
                 resize_rgb_dict['rgb'].transpose(0, 2, 3, 1)[0],
@@ -3866,7 +3866,7 @@ def DL_inpaint_edge(
                 None,
                 fx=frac, fy=frac,
                 interpolation=cv2.INTER_AREA)[None, None, :]
-            resize_rgb_dict['edge'] = (resize_rgb_dict['edge'] > 0).astype(np.float) * 0
+            resize_rgb_dict['edge'] = (resize_rgb_dict['edge'] > 0).astype(float) * 0
             resize_rgb_dict['edge'] = resize_rgb_dict['edge'] * (resize_rgb_dict['context'] + resize_rgb_dict['mask'])
         rgb_input_feat = np.concatenate((resize_rgb_dict['rgb'], resize_rgb_dict['edge']), axis=1)
         rgb_input_feat[:, 3] = 1 - rgb_input_feat[:, 3]

--- a/image_inpainting/deepfillv2/deepfillv2_utils.py
+++ b/image_inpainting/deepfillv2/deepfillv2_utils.py
@@ -25,8 +25,8 @@ def np_free_form_mask(maxVertex, maxLength, maxBrushWidth, maxAngle, h, w):
         nextY = startY + length * np.cos(angle)
         nextX = startX + length * np.sin(angle)
 
-        nextY = np.maximum(np.minimum(nextY, h - 1), 0).astype(np.int)
-        nextX = np.maximum(np.minimum(nextX, w - 1), 0).astype(np.int)
+        nextY = np.maximum(np.minimum(nextY, h - 1), 0).astype(int)
+        nextX = np.maximum(np.minimum(nextX, w - 1), 0).astype(int)
 
         cv2.line(mask, (startY, startX), (nextY, nextX), 1, brushWidth)
         cv2.circle(mask, (startY, startX), brushWidth // 2, 2)

--- a/image_inpainting/inpainting_gmcnn/inpainting_gmcnn_utils.py
+++ b/image_inpainting/inpainting_gmcnn/inpainting_gmcnn_utils.py
@@ -25,8 +25,8 @@ def np_free_form_mask(maxVertex, maxLength, maxBrushWidth, maxAngle, h, w):
         nextY = startY + length * np.cos(angle)
         nextX = startX + length * np.sin(angle)
 
-        nextY = np.maximum(np.minimum(nextY, h - 1), 0).astype(np.int)
-        nextX = np.maximum(np.minimum(nextX, w - 1), 0).astype(np.int)
+        nextY = np.maximum(np.minimum(nextY, h - 1), 0).astype(int)
+        nextX = np.maximum(np.minimum(nextX, w - 1), 0).astype(int)
 
         cv2.line(mask, (startY, startX), (nextY, nextX), 1, brushWidth)
         cv2.circle(mask, (startY, startX), brushWidth // 2, 2)

--- a/image_manipulation/style2paints/style2paints_utils.py
+++ b/image_manipulation/style2paints/style2paints_utils.py
@@ -190,7 +190,7 @@ def opreate_normal_hint(gird, points, type, length):
 
 
 def s_enhance(x, k=2.0):
-    p = cv2.cvtColor(x, cv2.COLOR_RGB2HSV).astype(np.float)
+    p = cv2.cvtColor(x, cv2.COLOR_RGB2HSV).astype(float)
     p[:, :, 1] *= k
     p = p.clip(0, 255).astype(np.uint8)
     return cv2.cvtColor(p, cv2.COLOR_HSV2RGB).clip(0, 255)

--- a/image_segmentation/yet-another-anime-segmenter/yaas_utils.py
+++ b/image_segmentation/yet-another-anime-segmenter/yaas_utils.py
@@ -106,7 +106,7 @@ def point_nms(heat, kernel=2):
     """
     # kernel must be 2
     hmax = np.expand_dims(pool2d(heat.squeeze(), kernel, 1, 1), (0, 1))
-    keep = (hmax[:, :, :-1, :-1] == heat).astype(np.float)
+    keep = (hmax[:, :, :-1, :-1] == heat).astype(float)
     return heat * keep
 
 def matrix_nms(cate_labels, seg_masks, sum_masks, cate_scores, sigma=2.0, kernel='gaussian'):

--- a/object_detection/centernet/centernet.py
+++ b/object_detection/centernet/centernet.py
@@ -116,7 +116,7 @@ def detect_objects(org_img, net):
 
     for det in dets:
         # Make sure bboxes are not out of bounds
-        xmin, ymin, xmax, ymax = det[:4].astype(np.int)
+        xmin, ymin, xmax, ymax = det[:4].astype(int)
         xmin = max(0, xmin)
         ymin = max(0, ymin)
         xmax = min(org_img.shape[1], xmax)

--- a/object_detection/centernet/centernet_utils.py
+++ b/object_detection/centernet/centernet_utils.py
@@ -67,8 +67,8 @@ def topk(scores, k=40):
     topk_inds = np.argpartition(scores, -k, axis=1)[:, -k:]
     topk_scores = scores[np.arange(scores.shape[0])[:, None], topk_inds]
 
-    topk_ys = (topk_inds / width).astype(np.int32).astype(np.float)
-    topk_xs = (topk_inds % width).astype(np.int32).astype(np.float)
+    topk_ys = (topk_inds / width).astype(np.int32).astype(float)
+    topk_xs = (topk_inds % width).astype(np.int32).astype(float)
 
     topk_scores = topk_scores.reshape((-1))
     topk_ind = np.argpartition(topk_scores, -k)[-k:]

--- a/object_detection/efficientdet/efficientdet.py
+++ b/object_detection/efficientdet/efficientdet.py
@@ -195,7 +195,7 @@ def convert_to_ailia_detector_object(preds, w, h):
     i = 0
     detector_object = []
     for j in range(len(preds[i]['rois'])):
-        (x1, y1, x2, y2) = preds[i]['rois'][j].astype(np.int)
+        (x1, y1, x2, y2) = preds[i]['rois'][j].astype(int)
         obj = preds[i]['class_ids'][j]
         score = float(preds[i]['scores'][j])
 

--- a/object_detection/glip/anchor.py
+++ b/object_detection/glip/anchor.py
@@ -12,13 +12,13 @@ def generate_anchors(
     """
 
     base_size = stride
-    scales = np.array(sizes, dtype=np.float) / stride
-    aspect_ratios = np.array(aspect_ratios, dtype=np.float),
+    scales = np.array(sizes, dtype=float) / stride
+    aspect_ratios = np.array(aspect_ratios, dtype=float),
 
     """Generate anchor (reference) windows by enumerating aspect ratios X
     scales wrt a reference (0, 0, base_size - 1, base_size - 1) window.
     """
-    anchor = np.array([1, 1, base_size, base_size], dtype=np.float) - 1
+    anchor = np.array([1, 1, base_size, base_size], dtype=float) - 1
     anchors = _ratio_enum(anchor, aspect_ratios)
     anchors = np.vstack(
         [_scale_enum(anchors[i, :], scales) for i in range(anchors.shape[0])]

--- a/object_detection/yolact/yolact_util.py
+++ b/object_detection/yolact/yolact_util.py
@@ -776,7 +776,7 @@ def nms(dets, thresh):
     order = scores.argsort()[::-1]
 
     ndets = dets.shape[0]
-    suppressed = np.zeros((ndets), dtype=np.int)
+    suppressed = np.zeros((ndets), dtype=int)
 
     for _i in range(ndets):
         i = order[_i]

--- a/object_detection_3d/3d_bbox/lib_3d_bbox/Dataset.py
+++ b/object_detection_3d/3d_bbox/lib_3d_bbox/Dataset.py
@@ -287,7 +287,7 @@ class DetectedObject:
     def format_img(self, img, box_2d):
 
         # Should this happen? or does normalize take care of it. YOLO doesnt like
-        # img=img.astype(np.float) / 255
+        # img=img.astype(float) / 255
 
         # torch transforms
         normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],

--- a/object_detection_3d/3d_bbox/lib_3d_bbox/Math.py
+++ b/object_detection_3d/3d_bbox/lib_3d_bbox/Math.py
@@ -160,7 +160,7 @@ def calc_location(dimension, proj_matrix, box_2d, alpha, theta_ray):
         M_array = [Ma, Mb, Mc, Md]
 
         # create A, b
-        A = np.zeros([4,3], dtype=np.float)
+        A = np.zeros([4,3], dtype=float)
         b = np.zeros([4,1])
 
         indicies = [0,1,0,1]

--- a/object_tracking/bytetrack/tracker/byte_tracker.py
+++ b/object_tracking/bytetrack/tracker/byte_tracker.py
@@ -10,7 +10,7 @@ class STrack(BaseTrack):
 
     def __init__(self, tlwh, score):
         # wait activate
-        self._tlwh = np.asarray(tlwh, dtype=np.float)
+        self._tlwh = np.asarray(tlwh, dtype=float)
         self.kalman_filter = None
         self.mean, self.covariance = None, None
         self.is_activated = False

--- a/object_tracking/bytetrack/tracker/matching.py
+++ b/object_tracking/bytetrack/tracker/matching.py
@@ -106,7 +106,7 @@ def ious(atlbrs, btlbrs):
 
     :rtype ious np.ndarray
     """
-    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=np.float)
+    ious = np.zeros((len(atlbrs), len(btlbrs)), dtype=float)
     if ious.size == 0:
         return ious
 

--- a/object_tracking/deepsort/deepsort.py
+++ b/object_tracking/deepsort/deepsort.py
@@ -206,7 +206,7 @@ def recognize_from_video():
             box = track.to_tlwh()
             x1, y1, x2, y2 = tlwh_to_xyxy(box, h, w)
             track_id = track.track_id
-            outputs.append(np.array([x1, y1, x2, y2, track_id], dtype=np.int))
+            outputs.append(np.array([x1, y1, x2, y2, track_id], dtype=int))
         if len(outputs) > 0:
             outputs = np.stack(outputs, axis=0)
 

--- a/object_tracking/deepsort/deepsort_utils.py
+++ b/object_tracking/deepsort/deepsort_utils.py
@@ -28,7 +28,7 @@ class Detection(object):
     """
 
     def __init__(self, tlwh, confidence, feature):
-        self.tlwh = np.asarray(tlwh, dtype=np.float)
+        self.tlwh = np.asarray(tlwh, dtype=float)
         self.confidence = float(confidence)
         self.feature = np.asarray(feature, dtype=np.float32)
 
@@ -166,7 +166,7 @@ def non_max_suppression(boxes, max_bbox_overlap, scores=None):
     if len(boxes) == 0:
         return []
 
-    boxes = boxes.astype(np.float)
+    boxes = boxes.astype(float)
     pick = []
 
     x1 = boxes[:, 0]

--- a/object_tracking/qd-3dt/motion_tracker.py
+++ b/object_tracking/qd-3dt/motion_tracker.py
@@ -255,7 +255,7 @@ class MotionTracker:
         depth_uncertainty = depth_uncertainty[inds]
 
         if pure_det:
-            valids = np.ones((bboxes.shape[0]), dtype=np.bool)
+            valids = np.ones((bboxes.shape[0]), dtype=bool)
             ids = np.arange(
                 self.num_tracklets,
                 self.num_tracklets + bboxes.shape[0],

--- a/object_tracking/qd-3dt/video_utils.py
+++ b/object_tracking/qd-3dt/video_utils.py
@@ -154,7 +154,7 @@ class VID:
 
     def getImgIdsFromVidId(self, videoId):
         img_infos = self.videoToImgs[videoId]
-        ids = list(np.zeros([len(img_infos)], dtype=np.int))
+        ids = list(np.zeros([len(img_infos)], dtype=int))
         for img_info in img_infos:
             ids[img_info['index']] = img_info['id']
         return ids

--- a/object_tracking/siam-mot/track_utils.py
+++ b/object_tracking/siam-mot/track_utils.py
@@ -271,7 +271,7 @@ class TrackHead(object):
         active_ids = self.track_pool.get_active_ids()
 
         ids = target.ids.tolist()
-        idxs = np.zeros((len(ids),), dtype=np.bool)
+        idxs = np.zeros((len(ids),), dtype=bool)
         for _i, _id in enumerate(ids):
             if _id in active_ids:
                 idxs[_i] = True

--- a/optical_flow_estimation/raft/raft.py
+++ b/optical_flow_estimation/raft/raft.py
@@ -265,8 +265,8 @@ def grid_sample(image, grid, padding_mode='border', align_corners=False):
 
     c = np.zeros_like(y) + np.arange(C)[np.newaxis, :, np.newaxis, np.newaxis]
     n = np.zeros_like(y) + np.arange(N)[:, np.newaxis, np.newaxis, np.newaxis]
-    c = c.astype(np.int)
-    n = n.astype(np.int)
+    c = c.astype(int)
+    n = n.astype(int)
 
     # Unnormalize with align_corners condition
     ix = grid_sampler_compute_source_index(x, W, align_corners)
@@ -287,10 +287,10 @@ def grid_sample(image, grid, padding_mode='border', align_corners=False):
     # Get values of the image by provided x0,y0,x1,y1 by channel
 
     # image, n, c, x, y, H, W
-    x0 = x0.astype(np.int)
-    y0 = y0.astype(np.int)
-    x1 = x1.astype(np.int)
-    y1 = y1.astype(np.int)
+    x0 = x0.astype(int)
+    y0 = y0.astype(int)
+    x1 = x1.astype(int)
+    y1 = y1.astype(int)
     Ia = safe_get(image, n, c, x0, y0, H, W, padding_mode)
     Ib = safe_get(image, n, c, x0, y1, H, W, padding_mode)
     Ic = safe_get(image, n, c, x1, y0, H, W, padding_mode)

--- a/pose_estimation/animalpose/animalpose_utils.py
+++ b/pose_estimation/animalpose/animalpose_utils.py
@@ -230,7 +230,7 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
 
     index = coords[..., 0] + 1 + (coords[..., 1] + 1) * (W + 2)
     index += (W + 2) * (H + 2) * np.arange(0, B * K).reshape(-1, K)
-    index = index.astype(np.int).reshape(-1, 1)
+    index = index.astype(int).reshape(-1, 1)
     i_ = batch_heatmaps_pad[index]
     ix1 = batch_heatmaps_pad[index + 1]
     iy1 = batch_heatmaps_pad[index + W + 2]
@@ -404,7 +404,7 @@ def keypoints_from_heatmaps(
             preds, maxvals = _get_max_preds(heatmaps)
             index = preds[..., 0] + preds[..., 1] * W
             index += W * H * np.arange(0, N * K / 3)
-            index = index.astype(np.int).reshape(N, K // 3, 1)
+            index = index.astype(int).reshape(N, K // 3, 1)
             preds += np.concatenate((offset_x[index], offset_y[index]), axis=2)
     else:
         preds, maxvals = _get_max_preds(heatmaps)

--- a/pose_estimation/ap-10k/ap_10k_utils.py
+++ b/pose_estimation/ap-10k/ap_10k_utils.py
@@ -220,7 +220,7 @@ def post_dark_udp(coords, batch_heatmaps, kernel=3):
 
     index = coords[..., 0] + 1 + (coords[..., 1] + 1) * (W + 2)
     index += (W + 2) * (H + 2) * np.arange(0, B * K).reshape(-1, K)
-    index = index.astype(np.int).reshape(-1, 1)
+    index = index.astype(int).reshape(-1, 1)
     i_ = batch_heatmaps_pad[index]
     ix1 = batch_heatmaps_pad[index + 1]
     iy1 = batch_heatmaps_pad[index + W + 2]
@@ -394,7 +394,7 @@ def keypoints_from_heatmaps(
             preds, maxvals = _get_max_preds(heatmaps)
             index = preds[..., 0] + preds[..., 1] * W
             index += W * H * np.arange(0, N * K / 3)
-            index = index.astype(np.int).reshape(N, K // 3, 1)
+            index = index.astype(int).reshape(N, K // 3, 1)
             preds += np.concatenate((offset_x[index], offset_y[index]), axis=2)
     else:
         preds, maxvals = _get_max_preds(heatmaps)

--- a/pose_estimation_3d/3dmppe_posenet/3dmppe_posenet.py
+++ b/pose_estimation_3d/3dmppe_posenet/3dmppe_posenet.py
@@ -527,7 +527,7 @@ def recognize_from_image(img_path, net_maskrcnn, net_root, net_pose):
         bbox_list = maskrcnn_to_image(image=image, net_maskrcnn=net_maskrcnn)
         bbox_list[:, 2] = bbox_list[:, 2] - bbox_list[:, 0]
         bbox_list[:, 3] = bbox_list[:, 3] - bbox_list[:, 1]
-        # print('bbox_list =\n', (bbox_list).astype(np.int))
+        # print('bbox_list =\n', (bbox_list).astype(int))
 
         # exec posenet
         vis_img = posenet_to_image(original_img=original_img, bbox_list=bbox_list, 

--- a/road_detection/cdnet/post_utils.py
+++ b/road_detection/cdnet/post_utils.py
@@ -201,7 +201,7 @@ class DmPost(object):
         else:
             self.imgputText(img, f'speed: {speed}', pos, lt, tf)
 
-        vt = vectors[vectors[:, 0] != -2].astype(np.int)  # Filter t
+        vt = vectors[vectors[:, 0] != -2].astype(int)  # Filter t
         if vector is not None:
             self.imgplotVectors(img, vt)
 
@@ -225,7 +225,7 @@ class DmPost(object):
                     c_fileorder = int(crossout[index, 2])
                     if (c_fileorder - self.old_fileorder) < self.frame_thresh:  # 10
                         print('\nxxx', c_fileorder, self.old_fileorder, self.frame_thresh)
-                        vto = self.old_vectors[self.old_vectors[:, 0] != -2].astype(np.int)
+                        vto = self.old_vectors[self.old_vectors[:, 0] != -2].astype(int)
                         new_vt = np.concatenate((vto, vt), axis=0)
                         self.imgplotVectors(img, new_vt)
                         vectors[:new_vt.shape[0], :] = new_vt

--- a/style_transfer/psgan/psgan/postprocess.py
+++ b/style_transfer/psgan/psgan/postprocess.py
@@ -15,9 +15,9 @@ class PostProcess:
 
         height, width = source.shape[:2]
         small_source = cv2.resize(source, (self.img_size, self.img_size))
-        laplacian_diff = source.astype(np.float) - cv2.resize(
+        laplacian_diff = source.astype(float) - cv2.resize(
             small_source, (width, height)
-        ).astype(np.float)
+        ).astype(float)
         result = (
             (cv2.resize(result, (width, height)) + laplacian_diff)
             .round()

--- a/style_transfer/psgan/psgan/preprocess.py
+++ b/style_transfer/psgan/psgan/preprocess.py
@@ -341,7 +341,7 @@ def _get_preds_from_hm(hm):
     )
     idx += 1
     preds = idx.reshape(idx.shape[0], idx.shape[1], 1)
-    preds = np.tile(preds, (1, 1, 2)).astype(np.float)
+    preds = np.tile(preds, (1, 1, 2)).astype(float)
     preds[..., 0] = (preds[..., 0] - 1) % hm.shape[3] + 1
     preds[..., 1] = np.floor((preds[..., 1] - 1) / (hm.shape[2])) + 1
 
@@ -355,7 +355,7 @@ def _get_preds_from_hm(hm):
                         hm_[pY, pX + 1] - hm_[pY, pX - 1],
                         hm_[pY + 1, pX] - hm_[pY - 1, pX],
                     ]
-                ).astype(np.float)
+                ).astype(float)
                 preds[i, j] = preds[i, j] + (np.sign(diff) * 0.25)
 
     preds += -0.5
@@ -405,4 +405,4 @@ def _transform(point, center, scale, resolution, invert=False):
     if invert:
         t = np.linalg.inv(t)
     new_point = (np.dot(t, _pt))[0:2]
-    return new_point.astype(np.int)
+    return new_point.astype(int)

--- a/text_detection/pixel_link/pixel_link_utils.py
+++ b/text_detection/pixel_link/pixel_link_utils.py
@@ -41,7 +41,7 @@ def decode_image(
     #
     pixel_mask = pixel_scores >= pixel_conf_threshold
     link_mask = link_scores >= link_conf_threshold
-    done_mask = np.zeros(pixel_mask.shape, np.bool)
+    done_mask = np.zeros(pixel_mask.shape, bool)
     result_mask = np.zeros(pixel_mask.shape, np.int32)
     points = list(zip(*np.where(pixel_mask)))
     h, w = np.shape(pixel_mask)

--- a/text_recognition/paddleocr/paddleocr.py
+++ b/text_recognition/paddleocr/paddleocr.py
@@ -542,10 +542,10 @@ class DBPostProcess(object):
     def box_score_fast(self, bitmap, _box):
         h, w = bitmap.shape[:2]
         box = _box.copy()
-        xmin = np.clip(np.floor(box[:, 0].min()).astype(np.int), 0, w - 1)
-        xmax = np.clip(np.ceil(box[:, 0].max()).astype(np.int), 0, w - 1)
-        ymin = np.clip(np.floor(box[:, 1].min()).astype(np.int), 0, h - 1)
-        ymax = np.clip(np.ceil(box[:, 1].max()).astype(np.int), 0, h - 1)
+        xmin = np.clip(np.floor(box[:, 0].min()).astype(int), 0, w - 1)
+        xmax = np.clip(np.ceil(box[:, 0].max()).astype(int), 0, w - 1)
+        ymin = np.clip(np.floor(box[:, 1].min()).astype(int), 0, h - 1)
+        ymax = np.clip(np.ceil(box[:, 1].max()).astype(int), 0, h - 1)
 
         mask = np.zeros((ymax - ymin + 1, xmax - xmin + 1), dtype=np.uint8)
         box[:, 0] = box[:, 0] - xmin

--- a/util/detector_utils.py
+++ b/util/detector_utils.py
@@ -139,7 +139,7 @@ def plot_results(detector, img, category=None, segm_masks=None, logging=True):
     # draw segmentation area
     if segm_masks:
         for idx in range(count):
-            mask = np.repeat(np.expand_dims(segm_masks[idx], 2), 3, 2).astype(np.bool)
+            mask = np.repeat(np.expand_dims(segm_masks[idx], 2), 3, 2).astype(bool)
             color = colors[idx][:3]
             fill = np.repeat(np.repeat([[color]], img.shape[0], 0), img.shape[1], 1)
             img[:, :, :3][mask] = img[:, :, :3][mask] * 0.7 + fill[mask] * 0.3

--- a/util/functional/grid_sample.py
+++ b/util/functional/grid_sample.py
@@ -55,8 +55,8 @@ def _grid_sample(
 
     c = np.zeros_like(y) + np.arange(C)[np.newaxis, :, np.newaxis, np.newaxis]
     n = np.zeros_like(y) + np.arange(N)[:, np.newaxis, np.newaxis, np.newaxis]
-    c = c.astype(np.int)
-    n = n.astype(np.int)
+    c = c.astype(int)
+    n = n.astype(int)
 
     # Unnormalize with align_corners condition
     ix = grid_sampler_compute_source_index(x, W, align_corners)
@@ -77,10 +77,10 @@ def _grid_sample(
     # Get values of the image by provided x0,y0,x1,y1 by channel
 
     # image, n, c, x, y, H, W
-    x0 = x0.astype(np.int)
-    y0 = y0.astype(np.int)
-    x1 = x1.astype(np.int)
-    y1 = y1.astype(np.int)
+    x0 = x0.astype(int)
+    y0 = y0.astype(int)
+    x1 = x1.astype(int)
+    y1 = y1.astype(int)
     Ia = safe_get(image, n, c, x0, y0, H, W, padding_mode)
     Ib = safe_get(image, n, c, x0, y1, H, W, padding_mode)
     Ic = safe_get(image, n, c, x1, y0, H, W, padding_mode)


### PR DESCRIPTION
numpy 1.20 [(release notes)](https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations) deprecated numpy.float, numpy.int, and similar aliases, causing them to issue a deprecation warning

numpy 1.24 [(release notes)](https://numpy.org/doc/stable/release/1.24.0-notes.html#expired-deprecations) removed these aliases altogether, causing an error when they are used