### PR TITLE
Fix error on poseresnet

### DIFF
--- a/action_recognition/ax_action_recognition/ax_action_recognition.py
+++ b/action_recognition/ax_action_recognition/ax_action_recognition.py
@@ -108,7 +108,7 @@ def ailia_to_openpose(person):
     pose_keypoints = np.zeros((18, 3))
     for i, key in enumerate(POSE_KEY):
         p = person.points[key]
-        pose_keypoints[i, :] = [p.x, p.y, p.score]
+        pose_keypoints[i, :] = [p.x, p.y, float(p.score)]
     return pose_keypoints
 
 # ======================


### PR DESCRIPTION
ax_action_recognitionをpose_resnet指定で実行した場合にエラーが発生する問題を修正するPRです。

```
python3 ax_action_recognition.py --video 0 -a pose_resnet
```

pose_resnet_utilのscoreがarrayを返すため、エラーになっています。

```
pose_keypoints[i, :] = [p.x, p.y, p.score]
ValueError: setting an array element with a sequence. The requested array would exceed the maximum number of dimension of 1.
```

float(p.score)として修正します。