### PR TITLE
fix cp932 error at ndlocr_text_recognition

### DIFF
--- a/text_recognition/ndlocr_text_recognition/ndlocr_text_recognition.py
+++ b/text_recognition/ndlocr_text_recognition/ndlocr_text_recognition.py
@@ -57,7 +57,7 @@ args = update_parser(parser)
 # ======================
 
 def get_char_list():
-    with open(CHAR_FILE_PATH) as f:
+    with open(CHAR_FILE_PATH, encoding='utf-8') as f:
         char_list = f.read()
     char_list = '〓' + char_list.replace("\n", "")
     char_list = ['[CTCblank]'] + list(char_list)


### PR DESCRIPTION
Use `encoding="utf-8"` option argument with `open()` to solve cp932 error.

In windows (japanese) environmnet, the [text_recognition/ndlocr_text_recognition](https://github.com/axinc-ai/ailia-models/tree/master/text_recognition/ndlocr_text_recognition) shows following error.

```
C:\src\ailia-models\text_recognition\ndlocr_text_recognition>python ndlocr_text_recognition.py -e 0
 INFO utils.py (13) : Start!
 INFO utils.py (163) : env_id: 0
 INFO utils.py (166) : CPU
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO ndlocr_text_recognition.py (144) : demo.png
 INFO ndlocr_text_recognition.py (151) : Start inference...
Traceback (most recent call last):
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 195, in <module>
    main()
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 191, in main
    recognize_from_image(net)
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 168, in recognize_from_image
    text = predict(net, img)
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 136, in predict
    text = decode(preds[0])
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 111, in decode
    characters = get_char_list()
  File "C:\src\ailia-models\text_recognition\ndlocr_text_recognition\ndlocr_text_recognition.py", line 61, in get_char_list
    char_list = f.read()
UnicodeDecodeError: 'cp932' codec can't decode byte 0x97 in position 191: illegal multibyte sequence
```

After applying the patch for this PR, the script will run normally as follows.

```
C:\src\ailia-models\text_recognition\ndlocr_text_recognition>python ndlocr_text_recognition.py -e 0
 INFO utils.py (13) : Start!
 INFO utils.py (163) : env_id: 0
 INFO utils.py (166) : CPU
 INFO model_utils.py (84) : ONNX file and Prototxt file are prepared!
 INFO ndlocr_text_recognition.py (144) : demo.png
 INFO ndlocr_text_recognition.py (151) : Start inference...
 INFO ndlocr_text_recognition.py (171) :  recognized: 號壹第誌雜勢學洋東
 INFO ndlocr_text_recognition.py (175) : Script finished successfully.
```