### PR TITLE
update diffusion models memory_mode option

### DIFF
--- a/diffusion/latent-diffusion-inpainting/latent-diffusion-inpainting.py
+++ b/diffusion/latent-diffusion-inpainting/latent-diffusion-inpainting.py
@@ -323,7 +323,7 @@ def main():
         logger.info("This model requires 10GB or more memory.")
         memory_mode = ailia.get_memory_mode(
             reduce_constant=True, ignore_input_with_initializer=True,
-            reduce_interstage=False, reuse_interstage=False)
+            reduce_interstage=False, reuse_interstage=True)
         cond_stage_model = ailia.Net(
             MODEL_COND_STAGE_PATH, WEIGHT_COND_STAGE_PATH, env_id=env_id, memory_mode=memory_mode)
         diffusion_model = ailia.Net(

--- a/diffusion/latent-diffusion-superresolution/latent-diffusion-superresolution.py
+++ b/diffusion/latent-diffusion-superresolution/latent-diffusion-superresolution.py
@@ -351,7 +351,7 @@ def main():
         logger.info("This model requires 10GB or more memory.")
         memory_mode = ailia.get_memory_mode(
             reduce_constant=True, ignore_input_with_initializer=True,
-            reduce_interstage=False, reuse_interstage=False)
+            reduce_interstage=False, reuse_interstage=True)
         first_stage_decode = ailia.Net(
             MODEL_FST_DEC_PATH, WEIGHT_FST_DEC_PATH, env_id=env_id, memory_mode=memory_mode)
         diffusion_model = ailia.Net(

--- a/diffusion/latent-diffusion-txt2img/latent-diffusion-txt2img.py
+++ b/diffusion/latent-diffusion-txt2img/latent-diffusion-txt2img.py
@@ -411,7 +411,7 @@ def main():
         logger.info("This model requires 10GB or more memory.")
         memory_mode = ailia.get_memory_mode(
             reduce_constant=True, ignore_input_with_initializer=True,
-            reduce_interstage=False, reuse_interstage=False)
+            reduce_interstage=False, reuse_interstage=True)
         transformer_emb = ailia.Net(
             MODEL_TRANS_EMB_PATH, WEIGHT_TRANS_EMB_PATH, env_id=env_id, memory_mode=memory_mode)
         transformer_attn = ailia.Net(


### PR DESCRIPTION
all following data are measured with vulkan + ailia 1.2.14(beta3).

## inpainting

| GPU | before (mem=3) | after (mem=11) |
| -- | -- | -- |
| RTX A6000 (VRAM 48GB) | OK | OK |
| RTX A4000 (VRAM 16GB) | NG | NG |
| Radeon RX550 (VRAM 4GB) | NG | NG |

peak VRAM usage is changed from 38GB to 20GB.

## superresolution

| GPU | before (mem=3) | after (mem=11) |
| -- | -- | -- |
| RTX A6000 (VRAM 48GB) | OK | OK |
| RTX A4000 (VRAM 16GB) | NG | OK |
| Radeon RX550 (VRAM 4GB) | NG | NG |

peak VRAM usage is changed from 26GB to 10GB.

## superresolution

| GPU | before (mem=3) | after (mem=11) |
| -- | -- | -- |
| RTX A6000 (VRAM 48GB) | OK | OK |
| RTX A4000 (VRAM 16GB) | NG | OK |
| Radeon RX550 (VRAM 4GB) | NG | NG |

peak VRAM usage is changed from 40GB to 14GB.
