### PR TITLE
Implement workaround for matplotlib

### DIFF
--- a/object_tracking/qd-3dt/plot_tracking.py
+++ b/object_tracking/qd-3dt/plot_tracking.py
@@ -122,7 +122,11 @@ def fig2data(fig, size: tuple = None):
     # canvas.tostring_argb give pixmap in ARGB mode.
     buf = np.frombuffer(fig.canvas.tostring_argb(), dtype=np.uint8)
 
-    buf.shape = (h, w, 4)  # last dim: (alpha, r, g, b)
+    # workaround for macOS dpi issue
+    for dpi in range(1, 4):
+        if buf.shape[0] == h * w * dpi * dpi * 4:
+            buf.shape = (h * dpi, w * dpi, 4)  # last dim: (alpha, r, g, b)
+            break
 
     # Roll the ALPHA channel to have it in RGBA mode
     # buf = np.roll(buf, 3, axis=2)


### PR DESCRIPTION
matplotlibでcanvasをnumpy arrayに下記のコードに変換している。

```
w, h = fig.canvas.get_width_height()
buf = np.frombuffer(fig.canvas.tostring_argb(), dtype=np.uint8)
buf.shape = (h, w, 4) 
```

しかし、macOSのHighDPI環境では、get_width_heightの値が小さい値となってしまい、buf.shapeの設定でエラーが発生する。

matplotlib側の問題であるが、ワークアラウンドとしてdpiのサーチを実装する。