### PR TITLE
Reduce memory usage for large vocab

### DIFF
--- a/image_classification/clip/clip.py
+++ b/image_classification/clip/clip.py
@@ -173,7 +173,6 @@ def predict_text_feature(net, text):
         text_feature.append(output[0])
 
     text_feature = np.concatenate(text_feature)
-    print(text_feature.shape)
 
     text_feature = text_feature / np.linalg.norm(text_feature, ord=2, axis=-1, keepdims=True)
 


### PR DESCRIPTION
CLIPのText Embeddingの計算において、バッチサイズに上限を付与するPRです。imagenetの1000クラスラベルを与えた場合にout of memoryになる問題を解消します。

```
class_count=3
+ idx=0
  category=285[Egyptian Mau ]
  prob=0.4874098300933838
+ idx=1
  category=281[tabby cat ]
  prob=0.2485242486000061
+ idx=2
  category=282[tiger cat ]
  prob=0.02332211099565029
```