### PR TITLE
set memory_mode option some models

### DIFF
--- a/depth_estimation/hitnet/hitnet.py
+++ b/depth_estimation/hitnet/hitnet.py
@@ -185,7 +185,10 @@ def main():
         net = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
         logger.info(f'env_id: {args.env_id}')
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
     
 
     if args.video is not None:

--- a/depth_estimation/mobilestereonet/mobilestereonet.py
+++ b/depth_estimation/mobilestereonet/mobilestereonet.py
@@ -199,7 +199,10 @@ def main():
 
     # initialize
     if not args.onnx:
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
     else:
         import onnxruntime
         net = onnxruntime.InferenceSession(WEIGHT_PATH)

--- a/generative_adversarial_networks/encoder4editing/encoder4editing.py
+++ b/generative_adversarial_networks/encoder4editing/encoder4editing.py
@@ -590,8 +590,11 @@ def main():
 
     # initialize
     if not args.onnx:
-        net_enc = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id)
-        net_dec = ailia.Net(MODEL_DEC_PATH, WEIGHT_DEC_PATH, env_id=env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net_enc = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id, memory_mode=memory_mode)
+        net_dec = ailia.Net(MODEL_DEC_PATH, WEIGHT_DEC_PATH, env_id=env_id, memory_mode=memory_mode)
     else:
         import onnxruntime
         net_enc = onnxruntime.InferenceSession(WEIGHT_ENC_PATH)

--- a/generative_adversarial_networks/restyle-encoder/restyle-encoder.py
+++ b/generative_adversarial_networks/restyle-encoder/restyle-encoder.py
@@ -365,12 +365,15 @@ def main():
             check(FACE_DETECTOR_WEIGHT_PATH)
         logger.info('Debug OK.')
     else:
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
         if args.video is not None:
             # net initialize
-            net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
-            face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id)
+            net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
+            face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
             if args.toonify:
-                toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id)
+                toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
             else: 
                 toonify_net = None
             # video mode
@@ -407,21 +410,21 @@ def main():
                 # net initialize
                 if args.benchmark:
                     start = int(round(time.time() * 1000))
-                    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
-                    face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id)
+                    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
+                    face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
                     # toonification task
                     if args.toonify:
-                        toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id)
+                        toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
                     else: 
                         toonify_net = None
                     end = int(round(time.time() * 1000))
                     logger.info(f'\tailia initializing time {end - start} ms')
                 else:
-                    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
-                    face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id)
+                    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
+                    face_pool_net = ailia.Net(FACE_POOL_MODEL_PATH, FACE_POOL_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
                     # toonification task
                     if args.toonify:
-                        toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id)
+                        toonify_net = ailia.Net(TOONIFY_MODEL_PATH, TOONIFY_WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
                     else: 
                         toonify_net = None
                 # input image loop

--- a/image_manipulation/dehamer/dehamer.py
+++ b/image_manipulation/dehamer/dehamer.py
@@ -224,11 +224,10 @@ def main():
 
     # initialize
     if not args.onnx:
-        # memory_mode = ailia.get_memory_mode(
-        # reduce_constant=True, ignore_input_with_initializer=True,
-        # reduce_interstage=False, reuse_interstage=True)
-        # net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
     else:
         import onnxruntime
         net = onnxruntime.InferenceSession(WEIGHT_PATH)

--- a/image_manipulation/style2paints/style2paints.py
+++ b/image_manipulation/style2paints/style2paints.py
@@ -346,11 +346,14 @@ def main():
     check_and_download_models(WEIGHT_GIRD_PATH, MODEL_GIRD_PATH, REMOTE_PATH)
 
     # initialize
-    net_head = ailia.Net(MODEL_HEAD_PATH, WEIGHT_HEAD_PATH, env_id=args.env_id)
-    net_neck = ailia.Net(MODEL_NECK_PATH, WEIGHT_NECK_PATH, env_id=args.env_id)
-    net_baby = ailia.Net(MODEL_BABY_PATH, WEIGHT_BABY_PATH, env_id=args.env_id)
-    net_tail = ailia.Net(MODEL_TAIL_PATH, WEIGHT_TAIL_PATH, env_id=args.env_id)
-    net_gird = ailia.Net(MODEL_GIRD_PATH, WEIGHT_GIRD_PATH, env_id=args.env_id)
+    memory_mode = ailia.get_memory_mode(
+        reduce_constant=True, ignore_input_with_initializer=True,
+        reduce_interstage=False, reuse_interstage=True)
+    net_head = ailia.Net(MODEL_HEAD_PATH, WEIGHT_HEAD_PATH, env_id=args.env_id, memory_mode=memory_mode)
+    net_neck = ailia.Net(MODEL_NECK_PATH, WEIGHT_NECK_PATH, env_id=args.env_id, memory_mode=memory_mode)
+    net_baby = ailia.Net(MODEL_BABY_PATH, WEIGHT_BABY_PATH, env_id=args.env_id, memory_mode=memory_mode)
+    net_tail = ailia.Net(MODEL_TAIL_PATH, WEIGHT_TAIL_PATH, env_id=args.env_id, memory_mode=memory_mode)
+    net_gird = ailia.Net(MODEL_GIRD_PATH, WEIGHT_GIRD_PATH, env_id=args.env_id, memory_mode=memory_mode)
 
     dict_net = {
         "head": net_head,

--- a/object_detection/dab-detr/dab-deter.py
+++ b/object_detection/dab-detr/dab-deter.py
@@ -81,7 +81,10 @@ def recognize_from_image():
     if args.onnx:
         session = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
-        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id = args.env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id = args.env_id, memory_mode=memory_mode)
 
     # input image loop
     for image_path in args.input:
@@ -127,7 +130,10 @@ def recognize_from_video():
     if args.onnx:
         session = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
-        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id = args.env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id = args.env_id, memory_mode=memory_mode)
 
     capture = webcamera_utils.get_capture(args.video)
 

--- a/pose_estimation_3d/gast/gast.py
+++ b/pose_estimation_3d/gast/gast.py
@@ -420,6 +420,10 @@ def main():
 
     num_person = args.num_person
 
+    memory_mode = ailia.get_memory_mode(
+        reduce_constant=True, ignore_input_with_initializer=True,
+        reduce_interstage=False, reuse_interstage=True)
+
     # net initialize
     detector = ailia.Detector(
         MODEL_YOLOV3_PATH,
@@ -430,11 +434,12 @@ def main():
         range=ailia.NETWORK_IMAGE_RANGE_U_FP32,
         algorithm=ailia.DETECTOR_ALGORITHM_YOLOV3,
         env_id=args.env_id,
+        memory_mode=memory_mode,
     )
-    pose_net = ailia.Net(MODEL_POSE_PATH, WEIGHT_POSE_PATH, env_id=args.env_id)
+    pose_net = ailia.Net(MODEL_POSE_PATH, WEIGHT_POSE_PATH, env_id=args.env_id, memory_mode=memory_mode)
 
     if not args.onnx:
-        net = ailia.Net(MODEL_27FRAME_17JOINT_PATH, WEIGHT_27FRAME_17JOINT_PATH, env_id=args.env_id)
+        net = ailia.Net(MODEL_27FRAME_17JOINT_PATH, WEIGHT_27FRAME_17JOINT_PATH, env_id=args.env_id, memory_mode=memory_mode)
     else:
         import onnxruntime
         net = onnxruntime.InferenceSession(WEIGHT_27FRAME_17JOINT_PATH)

--- a/style_transfer/pix2pixHD/pix2pixhd.py
+++ b/style_transfer/pix2pixHD/pix2pixhd.py
@@ -186,7 +186,10 @@ def main():
 
     # initialize
     if not args.onnx:
-        net = ailia.Net(model_path, weight_path, env_id=env_id)
+        memory_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net = ailia.Net(model_path, weight_path, env_id=env_id, memory_mode=memory_mode)
     else:
         import onnxruntime
         net = onnxruntime.InferenceSession(weight_path)

--- a/super_resolution/rcan-it/rcan-it.py
+++ b/super_resolution/rcan-it/rcan-it.py
@@ -69,7 +69,10 @@ def inference(net,input_data):
 def recognize_from_image():
 
     # net initialize
-    net = ailia.Net(None, WEIGHT_PATH)
+    memory_mode = ailia.get_memory_mode(
+        reduce_constant=True, ignore_input_with_initializer=True,
+        reduce_interstage=False, reuse_interstage=True)
+    net = ailia.Net(None, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
     #logger.info(IMAGE_PATH)
 
     for image_path in args.input:
@@ -104,7 +107,10 @@ def recognize_from_image():
 
 def recognize_from_video():
     # net initialize
-    net = ailia.Net(None, WEIGHT_PATH)
+    memory_mode = ailia.get_memory_mode(
+        reduce_constant=True, ignore_input_with_initializer=True,
+        reduce_interstage=False, reuse_interstage=True)
+    net = ailia.Net(None, WEIGHT_PATH, env_id=args.env_id, memory_mode=memory_mode)
 
     capture = webcamera_utils.get_capture(args.video)
 


### PR DESCRIPTION
This PR aims to reduce vulkan error models by adding memory mode option.

| model | Vulkan<br>RTX A4000<br>VRAM 16GB | Vulkan<br>Radeon RX6600XT<br>VRAM 8GB | Vulkan<br>Radeon RX550<br>VRAM 4GB |
| -- | -- | -- | -- |
| hitnet | OK -> OK | NG -> NG | NG -> NG |
| mobilesereonet | NG -> OK | NG -> NG | NG -> NG |
| restyle-encoder |OK -> OK | NG -> OK | NG -> NG |
| dehamer | NG -> OK | NG -> NG | NG -> NG |
| style2paint | OK -> OK | NG -> OK | NG -> NG |
| dab-detr | OK -> OK | OK -> OK | NG -> OK |
| gast | OK -> OK | OK -> OK | NG -> OK |
| pix2pixHD | OK -> OK | NG -> OK | NG -> NG | 
| rcan-it |ignore env_id  -> OK | ignore env_id -> OK | ignore env_id -> OK |
