### PR TITLE
Fix constant feature map shape

### DIFF
--- a/generative_adversarial_networks/gfpgan/face_restoration.py
+++ b/generative_adversarial_networks/gfpgan/face_restoration.py
@@ -4,12 +4,13 @@ import numpy as np
 import cv2
 
 from nms_utils import nms_boxes
+from math import ceil
 
 
 def get_anchor(image_size):
-    feature_maps = [[144, 98], [72, 49], [36, 25]]
     min_sizes = [[16, 32], [64, 128], [256, 512]]
     steps = [8, 16, 32]
+    feature_maps = [[ceil(image_size[0]/step), ceil(image_size[1]/step)] for step in steps]
 
     anchors = []
     for k, f in enumerate(feature_maps):


### PR DESCRIPTION
GFPGANの顔検出のRetinaFaceのfeature mapのshapeが固定なため、入力画像の解像度が変化すると推論できない問題を修正。合わせて、ビデオ入力のRGB順を修正。