### PR TITLE
Replace DeepSpeech2 create_spectrogram to raw functions

### DIFF
--- a/audio_processing/deepspeech2/deepspeech2.py
+++ b/audio_processing/deepspeech2/deepspeech2.py
@@ -100,14 +100,14 @@ else:
 # ======================
 def create_spectrogram(wav):
     if args.ailia_audio:
-        spectrogram = ailia.audio.create_spectrogram(
+        stft = ailia.audio.spectrogram(
             wav,
             fft_n=WIN_LENGTH,
             hop_n=HOP_LENGTH,
             win_n=WIN_LENGTH,
             win_type="hamming",
         )
-        spec_length = np.array(([spectrogram.shape[1]-1]))
+        stft, _ = ailia.audio.magphase(stft)
     else:
         stft = librosa.stft(
             wav,
@@ -117,13 +117,14 @@ def create_spectrogram(wav):
             window='hamming',
         )
         stft, _ = librosa.magphase(stft)
-        spectrogram = np.log1p(stft)
-        spec_length = np.array(([stft.shape[1]-1]))
 
-        mean = spectrogram.mean()
-        std = spectrogram.std()
-        spectrogram -= mean
-        spectrogram /= std
+    spectrogram = np.log1p(stft)
+    spec_length = np.array(([stft.shape[1]-1]))
+
+    mean = spectrogram.mean()
+    std = spectrogram.std()
+    spectrogram -= mean
+    spectrogram /= std
     
     spectrogram = np.log1p(spectrogram)
     spectrogram = spectrogram[np.newaxis, np.newaxis, :, :]


### PR DESCRIPTION
ailia SDK 1.2.15に存在していたailia.audioのutility functionのcreate_spectrogramが紛らわしいため、1.2.16で削除予定である。
そのため、DeepSpeech2をstftに置き換える。