### PR TITLE
Fix some models

### DIFF
--- a/audio_processing/pytorch-dc-tts/pytorch_dc_tts_utils.py
+++ b/audio_processing/pytorch-dc-tts/pytorch_dc_tts_utils.py
@@ -84,7 +84,7 @@ def invert_spectrogram(spectrogram):
 """Get test data"""
 def get_test_data(sentence, max_n):
     normalized_sentences = [text_normalize(line).strip() + "E" for line in sentence]  # text normalization, E: EOS
-    texts = np.zeros((len(normalized_sentences), max_n + 1), np.long)
+    texts = np.zeros((len(normalized_sentences), max_n + 1), int)
     vocab = "PE abcdefghijklmnopqrstuvwxyz'.?"  # P: Padding, E: EOS.
     char2idx = {char: idx for idx, char in enumerate(vocab)}
     for i, sent in enumerate(normalized_sentences):

--- a/audio_processing/vall-e-x/models/vallex.py
+++ b/audio_processing/vall-e-x/models/vallex.py
@@ -68,10 +68,10 @@ class VALLE():
     def attn_mask(self, x_len, y_len):
         # x is text_prompt + text_tokens
         # y is audio_prompt + ar_decoder output
-        x_attn_mask_pad = np.zeros((x_len, x_len + y_len), dtype=np.bool)
+        x_attn_mask_pad = np.zeros((x_len, x_len + y_len), dtype=bool)
         x_attn_mask_pad[:,x_len:x_len + y_len] = True # Output read all input tokens
 
-        y_attn_mask = np.zeros((y_len, x_len + y_len), dtype=np.bool)
+        y_attn_mask = np.zeros((y_len, x_len + y_len), dtype=bool)
         for i in range(y_len):
             for j in range(y_len):
                 if i < j:

--- a/audio_processing/vall-e-x/vall-e-x.py
+++ b/audio_processing/vall-e-x/vall-e-x.py
@@ -66,6 +66,10 @@ parser.add_argument(
     '--top_k', '-top_k', default=100,
     help='top_k filtering for output token sampling. official value is -100 (top_k is disabled). ailia modified this value for stability.'
 )
+parser.add_argument(
+    '--seed', type=int, default=1023,
+    help='random seed'
+)
 args = update_parser(parser, check_input_type=False)
 
 # ======================
@@ -119,6 +123,9 @@ if args.input:
     text = args.input
 else:
     text ="音声合成のテストを行なっています。"
+
+if args.seed:
+    np.random.seed(args.seed)
 
 sampling_rate = 24000
 

--- a/background_removal/u2net-portrait-matting/u2net-portrait-matting.py
+++ b/background_removal/u2net-portrait-matting/u2net-portrait-matting.py
@@ -75,7 +75,7 @@ def preprocess(img):
 
     img = np.array(Image.fromarray(img).resize(
         (args.width, args.height),
-        resample=Image.ANTIALIAS))
+        resample=Image.LANCZOS))
 
     img = img / 255
     img = (img - mean) / std

--- a/depth_estimation/fcrn-depthprediction/fcrn-depthprediction.py
+++ b/depth_estimation/fcrn-depthprediction/fcrn-depthprediction.py
@@ -55,7 +55,7 @@ def recognize_from_image():
 
         # prepare input data
         img = Image.open(image_path)
-        img = img.resize([IMAGE_WIDTH,IMAGE_HEIGHT], Image.ANTIALIAS)
+        img = img.resize([IMAGE_WIDTH,IMAGE_HEIGHT], Image.LANCZOS)
         img = np.array(img).astype('float32')
         img = np.expand_dims(np.asarray(img), axis=0)
         img = img[:,:,:,0:3]

--- a/generative_adversarial_networks/restyle-encoder/align_crop.py
+++ b/generative_adversarial_networks/restyle-encoder/align_crop.py
@@ -126,7 +126,7 @@ def align_face(filepath, args, face_alignment_path, face_detector_path):
         shrink = int(np.floor(qsize / output_size * 0.5))
         if shrink > 1:
             rsize = (int(np.rint(float(img.size[0]) / shrink)), int(np.rint(float(img.size[1]) / shrink)))
-            img = img.resize(rsize, PIL.Image.ANTIALIAS)
+            img = img.resize(rsize, PIL.Image.LANCZOS)
             quad /= shrink
             qsize /= shrink
 
@@ -156,7 +156,7 @@ def align_face(filepath, args, face_alignment_path, face_detector_path):
         # Transform.
         img = img.transform((transform_size, transform_size), PIL.Image.QUAD, (quad + 0.5).flatten(), PIL.Image.BILINEAR)
         if output_size < transform_size:
-            img = img.resize((output_size, output_size), PIL.Image.ANTIALIAS)
+            img = img.resize((output_size, output_size), PIL.Image.LANCZOS)
 
         # Save aligned image.
         return img

--- a/image_classification/weather-prediction-from-image/weather_prediction_from_image_utils.py
+++ b/image_classification/weather-prediction-from-image/weather_prediction_from_image_utils.py
@@ -25,7 +25,7 @@ def _resize_image(img_org, base_size):
         base_height = base_size
         wpercent = base_height / float(img_org.size[1])
         wsize = int((float(img_org.size[0]) * float(wpercent)))
-        img = img_org.resize((wsize, base_height), Image.ANTIALIAS)
+        img = img_org.resize((wsize, base_height), Image.LANCZOS)
         if sky_side == 0:  # Left side is sky side, so keep it and crop right side
             img = img.crop(
                 (0, 0, base_size, img.size[1])
@@ -38,7 +38,7 @@ def _resize_image(img_org, base_size):
         base_width = base_size
         wpercent = base_width / float(img_org.size[0])
         hsize = int((float(img_org.size[1]) * float(wpercent)))
-        img = img_org.resize((base_width, hsize), Image.ANTIALIAS)
+        img = img_org.resize((base_width, hsize), Image.LANCZOS)
         img = img.crop(
             (0, 0, img.size[0], base_size)
         )  # Keeps sky area in image, crops from lower part

--- a/image_segmentation/group_vit/tokenizer.py
+++ b/image_segmentation/group_vit/tokenizer.py
@@ -177,7 +177,7 @@ class Tokenize:
         sot_token = self.tokenizer.encoder['<|startoftext|>']
         eot_token = self.tokenizer.encoder['<|endoftext|>']
         all_tokens = [[sot_token] + self.tokenizer.encode(text) + [eot_token] for text in texts]
-        result = np.zeros((len(all_tokens), self.max_seq_len), dtype=np.long)
+        result = np.zeros((len(all_tokens), self.max_seq_len), dtype=int)
 
         for i, tokens in enumerate(all_tokens):
             if len(tokens) > self.max_seq_len:

--- a/natural_language_processing/bert_sum_ext/bert_sum_ext.py
+++ b/natural_language_processing/bert_sum_ext/bert_sum_ext.py
@@ -78,7 +78,7 @@ def main():
     model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
     tokenizer = AutoTokenizer.from_pretrained('./bert/')
 
-    with open(args.file) as f:
+    with open(args.file, encoding="utf-8") as f:
         body = f.read()
     
     logger.info(f'Input file : {args.file}')

--- a/natural_language_processing/sentence_transformers_japanese/sentence_transformers_japanese.py
+++ b/natural_language_processing/sentence_transformers_japanese/sentence_transformers_japanese.py
@@ -51,7 +51,7 @@ def preprocess(file_path):
         from pdfminer.high_level import extract_text
         text = extract_text(file_path)
     else:
-        f = open(file_path, "r")
+        f = open(file_path, "r", encoding="utf-8")
         text = f.read()
         f.close()
     sents = text.replace('\n', '').split('。')

--- a/natural_language_processing/t5_base_japanese_title_generation/t5_base_japanese_title_generation.py
+++ b/natural_language_processing/t5_base_japanese_title_generation/t5_base_japanese_title_generation.py
@@ -42,6 +42,10 @@ parser.add_argument(
     '-o', '--onnx', action='store_true',
     help="Option to use onnxrutime to run or not."
 )
+parser.add_argument(
+    "--seed", type=int, default=None,
+    help="random seed",
+)
 args = update_parser(parser)
 
 
@@ -241,6 +245,9 @@ def preprocess_body(text: str) -> str:
     return normalize_text(text.replace("\n", " "))
 
 def main(args):
+    if args.seed is not None:
+        np.random.seed(args.seed)
+
     # download onnx and prototxt
     check_and_download_models(ENCODER_ONNX_PATH, ENCODER_PROTOTXT_PATH, REMOTE_PATH)
     check_and_download_models(DECODER_ONNX_PATH, DECODER_PROTOTXT_PATH, REMOTE_PATH)

--- a/natural_language_processing/t5_base_japanese_title_generation/t5_base_japanese_title_generation.py
+++ b/natural_language_processing/t5_base_japanese_title_generation/t5_base_japanese_title_generation.py
@@ -271,7 +271,7 @@ def main(args):
     else:
         for input_path in args.input:
             # load input file
-            with open(input_path, "r") as fi:
+            with open(input_path, "r", encoding="utf-8") as fi:
                 body = fi.read()
 
             # pre process
@@ -281,7 +281,7 @@ def main(args):
             most_plausible_title, _ = model.estimate(body_preprocessed, 21, temperature=1.0, top_k=50, top_p=0.3)
             logger.info("title: %s", most_plausible_title)
             save_path = get_savepath(args.savepath, input_path)
-            with open(save_path, "w") as fo:
+            with open(save_path, "w", encoding="utf-8") as fo:
                 fo.write(most_plausible_title)
 
 

--- a/object_detection/footandball/footandball.py
+++ b/object_detection/footandball/footandball.py
@@ -95,8 +95,8 @@ def predict(net, img):
     img = img[np.newaxis, :, :, :]
 
     # feedforward
-    if args.onnx is None:
-        output = net.predict(img)
+    if not args.onnx:
+        output = net.run(img)
     else:
         output = net.run([
             net.get_outputs()[0].name,
@@ -213,11 +213,11 @@ def main():
     env_id = args.env_id
 
     # initialize
-    if args.onnx is None:
+    if not args.onnx:
         net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
     else:
         import onnxruntime
-        net = onnxruntime.InferenceSession(WEIGHT_PATH)
+        net = onnxruntime.InferenceSession(WEIGHT_PATH, providers = ["CPUExecutionProvider", "CUDAExecutionProvider"])
 
     if args.video is not None:
         recognize_from_video(net)

--- a/object_tracking/siam-mot/track_utils.py
+++ b/object_tracking/siam-mot/track_utils.py
@@ -429,7 +429,7 @@ def get_locations(
 
     h0, w0 = template_fmap.shape[-2:]
     assert (h0 == w0)
-    border = np.int(np.floor(h0 / 2))
+    border = int(np.floor(h0 / 2))
     st_end_idx = int(border * up_scale)
     delta_x = delta_x[:, st_end_idx:-st_end_idx]
     delta_y = delta_y[:, st_end_idx:-st_end_idx]

--- a/point_segmentation/pointnet_pytorch/pointnet_pytorch.py
+++ b/point_segmentation/pointnet_pytorch/pointnet_pytorch.py
@@ -2,6 +2,7 @@ import sys
 import time
 
 import numpy as np
+import matplotlib
 import matplotlib.pyplot as plt
 
 import ailia
@@ -162,7 +163,10 @@ def recognize_from_points(filename, net_seg, net_cls):
         pred_seg = predict_seg(point, net_seg)
         pred_cls = predict_cls(point, net_cls)
 
-    cmap = plt.cm.get_cmap("hsv", 10)
+    if hasattr(matplotlib, "colormaps"):
+        cmap = matplotlib.colormaps["hsv"].resampled(10)
+    else:
+        cmap = plt.cm.get_cmap("hsv", 10)
     cmap = np.array([cmap(i) for i in range(10)])[:, :3]
     pred_color = cmap[pred_seg, :]
 

--- a/point_segmentation/pointnet_pytorch/pointnet_pytorch.py
+++ b/point_segmentation/pointnet_pytorch/pointnet_pytorch.py
@@ -177,7 +177,7 @@ def recognize_from_points(filename, net_seg, net_cls):
     X = point[:, 0]
     Y = point[:, 1]
     Z = point[:, 2]
-    ax.scatter(X, Y, Z, color=pred_color)
+    ax.scatter(X, Y, Z, c=pred_color)
 
     # adjust plot scale
     max_range = np.array([X.max() - X.min(), Y.max() - Y.min(), Z.max() - Z.min()]).max() * 0.5

--- a/pose_estimation_3d/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
+++ b/pose_estimation_3d/lightweight-human-pose-estimation-3d/lightweight-human-pose-estimation-3d.py
@@ -53,6 +53,10 @@ parser.add_argument(
     '--rotate3d', action='store_true', default=False,
     help='allowing 3D canvas rotation while on pause',
 )
+parser.add_argument(
+    '--put_fps', action='store_true', default=False,
+    help='put FPS on result image',
+)
 args = update_parser(parser)
 
 
@@ -212,8 +216,9 @@ def main():
             mean_time = current_time
         else:
             mean_time = mean_time * 0.95 + current_time * 0.05
-        cv2.putText(frame, 'FPS: {}'.format(int(1 / mean_time * 10) / 10),
-                    (40, 80), cv2.FONT_HERSHEY_COMPLEX, 1, (0, 0, 255))
+        if args.put_fps:
+            cv2.putText(frame, 'FPS: {}'.format(int(1 / mean_time * 10) / 10),
+                        (40, 80), cv2.FONT_HERSHEY_COMPLEX, 1, (0, 0, 255))
 
         if is_video:
             cv2.imshow('ICV 3D Human Pose Estimation', frame)

--- a/style_transfer/psgan/psgan/preprocess.py
+++ b/style_transfer/psgan/psgan/preprocess.py
@@ -295,7 +295,7 @@ class PreProcess:
         np_image = np.array(image).astype(np.float32)
         mask = self.face_parse.parse(cv2.resize(np_image, (512, 512)))
         # obtain face parsing result
-        # image = image.resize((512, 512), Image.ANTIALIAS)
+        # image = image.resize((512, 512), Image.LANCZOS)
         mask = np.array(
             Image.fromarray(mask).resize(
                 (self.img_size, self.img_size), resample=Image.NEAREST
@@ -304,7 +304,7 @@ class PreProcess:
         mask = np.expand_dims(mask, (0, 1))
 
         mask, diff = self.process(mask, lms)
-        image = image.resize((self.img_size, self.img_size), Image.ANTIALIAS)
+        image = image.resize((self.img_size, self.img_size), Image.LANCZOS)
         image = np.array(image).transpose((2, 0, 1)) / 255
         means = np.expand_dims([0.5, 0.5, 0.5], (1, 2))
         stds = np.expand_dims([0.5, 0.5, 0.5], (1, 2))

--- a/text_recognition/easyocr/easyocr_utils.py
+++ b/text_recognition/easyocr/easyocr_utils.py
@@ -409,9 +409,9 @@ def compute_ratio_and_resize(img, width, height, model_height):
     ratio = width/height
     if ratio<1.0:
         ratio = calculate_ratio(width,height)
-        img = cv2.resize(img,(model_height,int(model_height*ratio)), interpolation=Image.ANTIALIAS)
+        img = cv2.resize(img,(model_height,int(model_height*ratio)), interpolation=Image.LANCZOS)
     else:
-        img = cv2.resize(img,(int(model_height*ratio),model_height),interpolation=Image.ANTIALIAS)
+        img = cv2.resize(img,(int(model_height*ratio),model_height),interpolation=Image.LANCZOS)
     return img,ratio
 
 


### PR DESCRIPTION
新しめのパッケージで venv を作ったところパッケージのバージョン依存で動かない等の問題があるスクリプトを修正しました。
修正内容は以下の通りです。

- numpy 1.20.0 から deprecate になった numpy の組み込み型を使っている箇所を修正
    - 参考： https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated
- vall-e-x に乱数の種を指定する --seed オプションを追加
- Pillow のフィルタ指定の ANTIALIAS が 10.0.0 で削除されたので、同じ挙動となる LANCZOS に置換
    - 参考： https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#imageshow-viewer-show-file-file-argument
    - Pillow で ANTIALIAS と LANCZOS が同じものとして定義されたのは 2.7.0 の時で、Pillow 2.7.0 のリリースは 2015 年なので置換しても問題ないと判断しました
        - 参考：  https://pillow.readthedocs.io/en/stable/releasenotes/2.7.0.html#antialias-renamed-to-lanczos
- テキストファイルを開く際に encoding 指定がなくエラーになる箇所を修正
- footandball の onnx オプションによる分岐に問題があり必ず onnxruntime でしか推論されていなかったのを修正
- pointnet_pytorch で colormap 取得時に `get_cmap()` の deprecated の警告が出ていたのと、3次元プロットの scatter 関数の引数指定が間違っていたのを修正
- lightweight-human-pose-estimation-3d で出力画像に FPS の値が書かれるが、FPS を書くかどうかをオプションで指定できるように変更
