### PR TITLE
前処理のベクトルをBGR形式で評価するように修正

### DIFF
--- a/pose_estimation/pose_resnet/pose_resnet_util.py
+++ b/pose_estimation/pose_resnet/pose_resnet_util.py
@@ -148,8 +148,8 @@ def compute(net, original_img, offset_x, offset_y, scale_x, scale_y):
     scale = np.array([1, 1], dtype=np.float32)
 
     # BGR format
-    mean = [0.485, 0.456, 0.406]
-    std = [0.229, 0.224, 0.225]
+    mean = [0.406, 0.456, 0.485]
+    std = [0.225, 0.224, 0.229]
     input_data = (input_data/255.0 - mean) / std
     input_data = input_data[np.newaxis, :, :, :].transpose((0, 3, 1, 2))
 


### PR DESCRIPTION
# Issue Link
https://github.com/axinc-ai/ailia-models/issues/1225


## 作業内容
表題の通りです。前処理のベクトルについて、BGR形式で読み込んだ画像RGB順序の変換ベクトルを適用してしまっていたため、正しい順序で評価されるように修正しました。


### 確認した項目

README記載の参照コードを確認しました。

該当の前処理ベクトルは、以下の箇所で定義されています。
https://github.com/microsoft/human-pose-estimation.pytorch/blob/49f3f4458c9d5917c75c37a6db48c6a0d7cd89a1/pose_estimation/valid.py#L139


このコードでは画像をRGB形式で読み込んでいるため、以下のベクトルはRGB順序です。

```
mean=[0.485, 0.456, 0.406]
std=[0.229, 0.224, 0.225]
```


### その他メモ

以下のIssue曰く、pytorch のresnetにはRGB形式の画像を入力する必要があるとあります。
https://github.com/microsoft/human-pose-estimation.pytorch/issues/73

一方、[こちら](https://github.com/axinc-ai/ailia-models/blob/472714c5eddc226714819e04e78a721df2fc032e/pose_estimation/pose_resnet/pose_resnet.py#L268)の箇所でailia.NETWORK_IMAGE_FORMAT_RGBを指定しています。

これにより、推論時にBGRからRGBへ変換され問題なく動作すると理解しました。

