### PR TITLE
Add seed option to some models

### DIFF
--- a/diffusion/latent-diffusion-inpainting/latent-diffusion-inpainting.py
+++ b/diffusion/latent-diffusion-inpainting/latent-diffusion-inpainting.py
@@ -55,8 +55,13 @@ parser.add_argument(
     action='store_true',
     help='execute onnxruntime version.'
 )
+parser.add_argument(
+    '--seed', type=int, default=128,
+    help='random seed for input data and noise'
+)
 args = update_parser(parser)
 
+np.random.seed(args.seed)
 
 # ======================
 # Secondaty Functions

--- a/diffusion/latent-diffusion-superresolution/latent-diffusion-superresolution.py
+++ b/diffusion/latent-diffusion-superresolution/latent-diffusion-superresolution.py
@@ -53,8 +53,13 @@ parser.add_argument(
     action='store_true',
     help='execute onnxruntime version.'
 )
+parser.add_argument(
+    '--seed', type=int, default=128,
+    help='random seed for input data and noise'
+)
 args = update_parser(parser)
 
+np.random.seed(args.seed)
 
 # ======================
 # Secondaty Functions

--- a/generative_adversarial_networks/pytorch-gan/pytorch-gan.py
+++ b/generative_adversarial_networks/pytorch-gan/pytorch-gan.py
@@ -41,8 +41,13 @@ parser.add_argument(
     default=MODEL_NAME,
     help='Model to use ("anime" or "celeb". Default is "anime").'
 )
+parser.add_argument(
+    '--seed', type=int, default=128,
+    help='random seed for input data'
+)
 args = update_parser(parser)
 
+np.random.seed(args.seed)
 
 if args.model == 'anime':
     logger.info('Generation using model "AnimeFace"')


### PR DESCRIPTION
以下3つのモデルで乱数が使われていたため、乱数の種を指定するための `--seed` オプションを追加しました。

- diffusion/latent-diffusion-inpainting
- diffusion/latent-diffusion-superresolution
- generative_adversarial_networks/pytorch-gan