### PR TITLE
Update object_detection/layout_parsing

### DIFF
--- a/object_detection/layout_parsing/layout_parsing.py
+++ b/object_detection/layout_parsing/layout_parsing.py
@@ -64,11 +64,8 @@ def infer_from_pdf(detector: ailia.Detector):
         img_processed, ratio = preprocess(img_orig, INPUT_SHAPE)
 
         def compute():
-            if args.detector:
-                detector.compute(img_orig, args.threshold, args.iou)
-                return None
-            else:
-                return detector.run(img_processed)
+            detector.compute(img_orig, args.threshold, args.iou)
+            return None
 
         # inference
         logger.info('Start inference...')

--- a/object_detection/layout_parsing/layout_parsing_utils.py
+++ b/object_detection/layout_parsing/layout_parsing_utils.py
@@ -1,8 +1,9 @@
 from typing import List, Optional
 
+import os
+import sys
 import cv2
 import numpy as np
-import pdf2image
 
 
 def pdf_to_images(
@@ -11,6 +12,16 @@ def pdf_to_images(
     paths_only: bool = True,
     output_folder: Optional[str] = None,
 ) -> List[str]:
+    import pdf2image
+
+    if output_folder is not None:
+        if not os.path.exists(output_folder):
+            os.makedirs(output_folder)
+        else:
+            if not os.path.isdir(output_folder):
+                print("Failed to create output folder")
+                sys.exit(1)
+
     if output_folder is not None:
         image_paths = pdf2image.convert_from_path(
             pdf_filename,


### PR DESCRIPTION
object_detection/layout_parsing の修正を行いました。変更は以下の2点です。

- pdf2image の import 位置を調整し、画像を入力するだけであれば pdf2image のインストールを必須でないようにしました
- infer_from_pdf() 関数内で定義されている compute() 関数に args.detector 引数の値による分岐がありますが、layout_parsing には --detector オプションがないため、infer_from_image() 関数と同様の実装に変更しました