### PR TITLE
Fix resize function to be bilinear in clap.

### DIFF
--- a/audio_processing/clap/clap_utils.py
+++ b/audio_processing/clap/clap_utils.py
@@ -1,5 +1,6 @@
 import numpy as np
 import librosa
+from skimage.transform import resize
 
 
 def int16_to_float32(x):
@@ -102,11 +103,11 @@ def get_audio_features(sample, audio_data, max_len, data_truncating, data_fillin
                 mel_chunk_back = mel[idx_back:idx_back+chunk_frames, :]
 
                 # shrink the mel
-                # Output may differ between torchvision.transforms.Resize and numpy.resize.
+                # Output may differ between torchvision.transforms.Resize and skimage.transform.resize.
                 #mel_shrink_torch = torch.from_numpy(mel[None])
                 #mel_shrink_torch = torchvision.transforms.Resize(size=[chunk_frames, 64])(mel_shrink_torch)[0]
                 #mel_shrink_torch = mel_shrink_torch.to('cpu').detach().numpy().copy()
-                mel_shrink_numpy = np.resize(mel[None], (chunk_frames, 64))
+                mel_shrink_numpy = resize(mel, (chunk_frames, 64), preserve_range=True, anti_aliasing=True, mode='edge')
                 # logging.info(f"mel_shrink.shape: {mel_shrink.shape}")
 
                 # stack


### PR DESCRIPTION
clapサンプルで、メルスペクトログラム(2次元)をresizeして一定チャンクサイズにするコードが、
np.resize (インデックス0から詰め直すだけ) で実現されており、
目的は torchvision.transforms.Resize (線形補間) のため、2D線形補間となるよう修正します。

skimage.transform.resize　を用い、オプション引数も torchvisionの結果に近くなるようなオプションを選んでいます。
完全一致はしませんが、似たような結果が得られることを確認済。
他の候補としては cv2.resize, scipy.interpolate.interp2d, RegularGridInterpolator などがありますが、
１行で済み、cv2よりskimageのほうがinstallしやすいと思われるため、こちらにしました。

参考：
https://pytorch.org/vision/stable/generated/torchvision.transforms.Resize.html
https://numpy.org/devdocs/reference/generated/numpy.resize.html
https://scikit-image.org/docs/dev/api/skimage.transform.html#skimage.transform.resize
https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interp2d.html