### PR TITLE
add version limit for dlib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ fvcore
 ftfy
 webcolors
 pymatting
-dlib
+dlib==19.21.1
 lap


### PR DESCRIPTION
For dlib >= 19.22, it will segv on windows or the result may unstable sometime on linux.