### PR TITLE
fix Inatural_language_processing/glucose' error on windows environment

### DIFF
--- a/natural_language_processing/glucose/glucose.py
+++ b/natural_language_processing/glucose/glucose.py
@@ -117,7 +117,7 @@ def predict(models, sentences):
 
 
 def recognize_from_sentence(models):
-    with open(args.input[0]) as f:
+    with open(args.input[0], encoding='utf-8') as f:
         sentences = [s.strip() for s in f.read().split("\n")]
 
     logger.info(


### PR DESCRIPTION
## before this PR

```
D:\ailia\ailia-models\natural_language_processing\glucose>python glucose.py -e 0
 INFO arg_utils.py (13) : Start!
 INFO arg_utils.py (163) : env_id: 0
 INFO arg_utils.py (166) : CPU
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
Ignored unknown kwarg option special
Ignored unknown kwarg option special
Traceback (most recent call last):
  File "D:\ailia\ailia-models\natural_language_processing\glucose\glucose.py", line 196, in <module>
    main()
  File "D:\ailia\ailia-models\natural_language_processing\glucose\glucose.py", line 192, in main
    recognize_from_sentence(models)
  File "D:\ailia\ailia-models\natural_language_processing\glucose\glucose.py", line 121, in recognize_from_sentence
    sentences = [s.strip() for s in f.read().split("\n")]
UnicodeDecodeError: 'cp932' codec can't decode byte 0x92 in position 30: illegal multibyte sequence

D:\ailia\ailia-models\natural_language_processing\glucose>
```

## after this PR

```
D:\ailia\ailia-models\natural_language_processing\glucose>python glucose.py -e 0
 INFO arg_utils.py (13) : Start!
 INFO arg_utils.py (163) : env_id: 0
 INFO arg_utils.py (166) : CPU
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
Ignored unknown kwarg option special
Ignored unknown kwarg option special
 INFO glucose.py (123) : sentences:
#1. PKSHA Technologyは機械学習/深層学習技術に関わるアルゴリズムソリューションを展開している。
#2. この深層学習モデルはPKSHA Technologyによって学習され、公開された。
#3. 広目天は、仏教における四天王の一尊であり、サンスクリット語の「種々の眼をした者」を名前の由来とする。
 INFO glucose.py (129) : Start inference...
 INFO glucose.py (154) : The top similar are below.
#1 & #2 : 0.7544876594280631
#1 & #3 : 0.14178461623502997
#2 & #3 : 0.11260417116869655
 INFO glucose.py (167) : Script finished successfully.

D:\ailia\ailia-models\natural_language_processing\glucose>
```