### PR TITLE
Disable fp16 for blazepose-fullbody

### DIFF
--- a/pose_estimation_3d/blazepose-fullbody/blazepose-fullbody.py
+++ b/pose_estimation_3d/blazepose-fullbody/blazepose-fullbody.py
@@ -366,8 +366,13 @@ def main():
     weight_path, model_path = info[args.model]
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
 
-    env_id = args.env_id
+    # disable FP16
+    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
+        logger.warning('This model do not work on FP16. So use CPU mode.')
+        args.env_id = 0
 
+    env_id = args.env_id
+    
     # initialize
     det_net = ailia.Net(MODEL_DETECTOR_PATH, WEIGHT_DETECTOR_PATH, env_id=env_id)
     net = ailia.Net(model_path, weight_path, env_id=env_id)


### PR DESCRIPTION
blazepose-fullbodyはFP16では精度不足になるため、FP16を無効化する。
https://github.com/axell-corp/ailia/issues/5413