### PR TITLE
fix python script of depth_estimation/zoe_depth

### DIFF
--- a/depth_estimation/zoe_depth/zoe_depth_util.py
+++ b/depth_estimation/zoe_depth/zoe_depth_util.py
@@ -40,7 +40,10 @@ def postprocess(
 
     pred = (pred - vmin) / (vmax - vmin)
     pred[invalid_mask] = np.nan
-    cmapper = matplotlib.cm.get_cmap(cmap)
+    if hasattr(matplotlib, "colormaps"):
+        cmapper = matplotlib.colormaps[cmap]
+    else:
+        cmapper = matplotlib.cm.get_cmap(cmap)
     pred = cmapper(pred, bytes=True)
     img = pred[...]
     img[invalid_mask] = (128, 128, 128, 256)


### PR DESCRIPTION
depth_estimation/zoe_depth で `get_cmap()` でカラーマップを取得していますが、新しい matplotlib ではエラーとなるため、可能であれば `matplotlib.colormaps` からカラーマップを取得する処理を追加しました。

修正内容は pull request #1282 に含まれているものと同様です。