### PR TITLE
Use numpy 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -i https://pypi.org/simple
-numpy>=1.18.4
+numpy<2.0
 matplotlib>=3.2.1
 opencv-python>=4.4.0.42
 pillow>=7.1.2


### PR DESCRIPTION
numpy2対応はailia SDK 1.5.0からなので、当面はnumpy1にしておく。
opencv、scipyも動かないため。