### PR TITLE
GroundingDINOとGroundedSAMでailia Tokenizerを使用する

### DIFF
--- a/image_segmentation/grounded_sam/README.md
+++ b/image_segmentation/grounded_sam/README.md
@@ -20,7 +20,7 @@
 This model requires additional module.
 
 ```
-pip3 install transformers
+pip3 install ailia_tokenizer
 ```
 
 ## Usage

--- a/image_segmentation/grounded_sam/grounded_sam.py
+++ b/image_segmentation/grounded_sam/grounded_sam.py
@@ -5,7 +5,6 @@ import time
 import numpy as np
 import cv2
 from PIL import Image
-from transformers import AutoTokenizer
 
 import ailia
 
@@ -59,6 +58,11 @@ parser.add_argument(
     type=str,
     default="The running dog.",
     help="Text prompt.",
+)
+parser.add_argument(
+    '--disable_ailia_tokenizer',
+    action='store_true',
+    help='disable ailia tokenizer.'
 )
 parser.add_argument("--onnx", action="store_true", help="execute onnxruntime version.")
 args = update_parser(parser)
@@ -406,7 +410,13 @@ def main():
         grounding_dino = onnxruntime.InferenceSession(WEIGHT_GDINO_PATH)
         net = onnxruntime.InferenceSession(WEIGHT_PATH)
 
-    tokenizer = AutoTokenizer.from_pretrained("tokenizer")
+    if args.disable_ailia_tokenizer:
+        from transformers import AutoTokenizer
+        tokenizer = AutoTokenizer.from_pretrained("tokenizer")
+    else:
+        from ailia_tokenizer import BertUncasedTokenizer
+        tokenizer = BertUncasedTokenizer.from_pretrained("./tokenizer/vocab.txt")
+
     tokenizer.specical_tokens = tokenizer.convert_tokens_to_ids(
         ["[CLS]", "[SEP]", ".", "?"]
     )

--- a/object_detection/groundingdino/README.md
+++ b/object_detection/groundingdino/README.md
@@ -20,7 +20,7 @@
 This model requires additional module.
 
 ```
-pip3 install transformers
+pip3 install ailia_tokenizer
 ```
 
 ## Usage


### PR DESCRIPTION
transformersがtorchやtensorflowを読み込んでしまうため、ailia tokenizerに置き換え、transformersへの依存をなくす。
--disable_ailia_tokenizerオプションでtransformersを使用することもできる。