### PR TITLE
update requirements.txt for distil-whisper

### DIFF
--- a/audio_processing/requirements.txt
+++ b/audio_processing/requirements.txt
@@ -3,3 +3,4 @@ SoundFile
 librosa
 torch
 pyaudio
+transformers>=4.27.0,<=4.43.2

--- a/natural_language_processing/requirements.txt
+++ b/natural_language_processing/requirements.txt
@@ -1,5 +1,4 @@
 -i https://pypi.org/simple
-transformers>=3.4.0,<=4.22.0
 tokenizers>=0.7.0
 sentencepiece>=0.1.90
 sacremoses>=0.0.43

--- a/natural_language_processing/requirements.txt
+++ b/natural_language_processing/requirements.txt
@@ -1,4 +1,5 @@
 -i https://pypi.org/simple
+transformers>=4.27.0,<=4.43.2
 tokenizers>=0.7.0
 sentencepiece>=0.1.90
 sacremoses>=0.0.43

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ ftfy
 webcolors
 pymatting
 lapx
+transformers>=4.27.0,<=4.43.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,3 @@ ftfy
 webcolors
 pymatting
 lapx
-transformers>=4.27.0,<=4.43.2


### PR DESCRIPTION
This PR's changes:

* ~~moved `transformers` registration from `natural_language_processing` to repository top~~
* add `transformers` registration at `audio_processiong/requirements.txt` 
    * not only `natural_language_processing` , `audio_processing/distil-whisper` requires `transformers`
* updated version range of `transformers`
    * `distil-whisper` requires 4.27.0 or later


