### PR TITLE
fix python script of some object_tracking models

### DIFF
--- a/object_tracking/bytetrack/bytetrack.py
+++ b/object_tracking/bytetrack/bytetrack.py
@@ -3,7 +3,7 @@ import time
 
 import numpy as np
 import cv2
-from matplotlib import cm
+import matplotlib
 
 import ailia
 
@@ -102,7 +102,11 @@ def get_colors(n, colormap="gist_ncar"):
     # https://matplotlib.org/examples/color/colormaps_reference.html
     # and https://matplotlib.org/users/colormaps.html
 
-    colors = cm.get_cmap(colormap)(np.linspace(0, 1, n))
+    if hasattr(matplotlib, "colormaps"):
+        cm = matplotlib.colormaps[colormap]
+    else:
+        cm = matplotlib.cm.get_cmap(colormap)
+    colors = cm(np.linspace(0, 1, n))
     # Randomly shuffle the colors
     np.random.shuffle(colors)
     # Opencv expects bgr while cm returns rgb, so we swap to match the colormap (though it also works fine without)

--- a/object_tracking/siam-mot/siam-mot.py
+++ b/object_tracking/siam-mot/siam-mot.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 import cv2
 from PIL import Image
-from matplotlib import cm
+import matplotlib
 
 import ailia
 
@@ -89,7 +89,11 @@ def get_colors(n, colormap="gist_ncar"):
     # https://matplotlib.org/examples/color/colormaps_reference.html
     # and https://matplotlib.org/users/colormaps.html
 
-    colors = cm.get_cmap(colormap)(np.linspace(0, 1, n))
+    if hasattr(matplotlib, "colormaps"):
+        cm = matplotlib.colormaps[colormap]
+    else:
+        cm = matplotlib.cm.get_cmap(colormap)
+    colors = cm(np.linspace(0, 1, n))
     # Randomly shuffle the colors
     np.random.shuffle(colors)
     # Opencv expects bgr while cm returns rgb, so we swap to match the colormap (though it also works fine without)

--- a/object_tracking/strong_sort/strong_sort.py
+++ b/object_tracking/strong_sort/strong_sort.py
@@ -6,7 +6,7 @@ from logging import getLogger
 import numpy as np
 import cv2
 from PIL import Image
-from matplotlib import cm
+import matplotlib
 
 import ailia
 
@@ -124,7 +124,11 @@ def get_colors(n, colormap="gist_ncar"):
     # https://matplotlib.org/examples/color/colormaps_reference.html
     # and https://matplotlib.org/users/colormaps.html
 
-    colors = cm.get_cmap(colormap)(np.linspace(0, 1, n))
+    if hasattr(matplotlib, "colormaps"):
+        cm = matplotlib.colormaps[colormap]
+    else:
+        cm = matplotlib.cm.get_cmap(colormap)
+    colors = cm(np.linspace(0, 1, n))
     # Randomly shuffle the colors
     np.random.shuffle(colors)
     # Opencv expects bgr while cm returns rgb, so we swap to match the colormap (though it also works fine without)


### PR DESCRIPTION
以下3つのモデルで `matplot.cm.get_cmap()` によってカラーマップを取得しているコードが新しい matplotlib でエラーとなっていたので修正しました。(#1497 と同様の修正です)

- object_tracking/bytetrack
- object_tracking/siam-mot
- object_tracking/strong_sort