### PR TITLE
Update bert-vits2 and pytorch_wavenet

### DIFF
--- a/audio_processing/bert-vits2/bert-vits2.py
+++ b/audio_processing/bert-vits2/bert-vits2.py
@@ -71,6 +71,11 @@ parser.add_argument(
     help='disable ailia tokenizer.'
 )
 
+parser.add_argument(
+    '--seed', default=1000, type=int,
+    help='random seed'
+)
+
 args = update_parser(parser)
 
 
@@ -329,4 +334,5 @@ def main():
 
 
 if __name__ == "__main__":
+    np.random.seed(args.seed)
     main()

--- a/audio_processing/pytorch_wavenet/pytorch_wavenet.py
+++ b/audio_processing/pytorch_wavenet/pytorch_wavenet.py
@@ -107,7 +107,7 @@ def generate_wave(net, num_samples, first_samples=None, temperature=1.0):
 
     # generate new samples
     generated = np.array([])
-    for i in range(num_samples):
+    for i in range(int(num_samples)):
         x, dilated_queues = _inference(net, input, dilated_queues)
         x = x.squeeze()
 

--- a/audio_processing/pytorch_wavenet/pytorch_wavenet.py
+++ b/audio_processing/pytorch_wavenet/pytorch_wavenet.py
@@ -42,6 +42,10 @@ parser.add_argument(
 parser.add_argument(
     "--onnx", action="store_true", default=False, help="Use onnxruntime"
 )
+parser.add_argument(
+    '--seed', default=1000, type=int,
+    help='random seed'
+)
 args = update_parser(parser)
 
 
@@ -193,4 +197,5 @@ def main():
 
 
 if __name__ == "__main__":
+    np.random.seed(args.seed)
     main()


### PR DESCRIPTION
以下の変更を行いました。

 - bert-vits2
     - 乱数が使われていたため `--seed` オプションを追加
 - pytorch_wavenet
     - 乱数が使われていたため `--seed` オプションを追加
     - `--num_samples` オプションを指定した時 `range()` に float が渡ってエラーになることがあったので int へのキャストを追加