### PR TITLE
Disable torch by default for detic

### DIFF
--- a/object_detection/detic/detic.py
+++ b/object_detection/detic/detic.py
@@ -69,9 +69,9 @@ parser.add_argument(
     help='vocabulary'
 )
 parser.add_argument(
-    '--opset16',
+    '--legacy',
     action='store_true',
-    help='Use the opset16 model. In that case, grid_sampler runs inside the model.'
+    help='Use the legacy model. In that case, grid_sampler runs outside the model.'
 )
 parser.add_argument(
     '--onnx',
@@ -346,7 +346,7 @@ def predict(net, img):
     #img[:] = 0 # test for grid sampler
 
     # feedforward
-    if args.opset16:
+    if not args.legacy:
         if not args.onnx:
             output = net.predict([img, im_hw])
         else:
@@ -359,7 +359,7 @@ def predict(net, img):
 
     pred_boxes, scores, pred_classes, pred_masks = output
 
-    if not args.opset16:
+    if args.legacy:
         pred = post_processing(
             pred_boxes, scores, pred_classes, pred_masks,
             (im_h, im_w), pred_hw
@@ -462,7 +462,7 @@ def recognize_from_video(net):
 
 
 def main():
-    if args.opset16:
+    if not args.legacy:
         dic_model = {
             ('SwinB_896_4x', 'lvis'): (WEIGHT_SWINB_LVIS_OP16_PATH, MODEL_SWINB_LVIS_OP16_PATH),
             ('SwinB_896_4x', 'in21k'): (WEIGHT_SWINB_IN21K_OP16_PATH, MODEL_SWINB_IN21K_OP16_PATH),


### PR DESCRIPTION
従来はDeticがopset=11で動いていて、GridSamplerがtorchで動いていたが、macOSのarm64でtorchが例外を出すので、デフォルトをopset=16のGridSampler込みのモデルに変更。

```
Thread 24 crashed with ARM Thread State (64-bit):
    x0: 0x0000000000000001   x1: 0x00000002fc302b30   x2: 0xfffffb2123021d5e   x3: 0x0000000fffffc088
    x4: 0x0000000000000001   x5: 0x0000000000000000   x6: 0x0000000000000031   x7: 0x0000000000000000
    x8: 0x0000000000000000   x9: 0x000000007fffffff  x10: 0x00000000000003e8  x11: 0xd4e923e9477e005d
   x12: 0x00000000016e3600  x13: 0x000000000009a960  x14: 0x0000000000000000  x15: 0x0000000000000000
   x16: 0x000000013e41cbb8  x17: 0x00000001ec497220  x18: 0x0000000000000000  x19: 0x00000002f9742c40
   x20: 0x00000002fc302b30  x21: 0x00000002fc302b30  x22: 0x000000016a762c80  x23: 0x000000016a7585a8
   x24: 0x0000000000000001  x25: 0x0000000000000000  x26: 0x000000016a758548  x27: 0x00000002f9743188
   x28: 0x000000016a75b1e0   fp: 0x00000002fc302a50   lr: 0x000000016a711520
    sp: 0x00000002fc3029a0   pc: 0x000000013e41cbe8 cpsr: 0x80001000
   far: 0x0000000000000008  esr: 0x92000006 (Data Abort) byte read Translation fault

Binary Images:
       0x16a684000 -        0x16a68ffff _asyncio.cpython-312-darwin.so (*) <71c18ad8-9577-3902-8bc9-713e05adb141> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/_asyncio.cpython-312-darwin.so
       0x16a650000 -        0x16a653fff _queue.cpython-312-darwin.so (*) <50765d10-ea71-33f6-a774-51bdce26b604> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/_queue.cpython-312-darwin.so
       0x2fa524000 -        0x2fa633fff unicodedata.cpython-312-darwin.so (*) <a4df5120-56aa-3d4a-87b8-2ed1ed5b6b98> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/unicodedata.cpython-312-darwin.so
       0x16a63c000 -        0x16a63ffff _uuid.cpython-312-darwin.so (*) <21e89ca6-8150-3d74-9670-4e74bafdfe1b> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/_uuid.cpython-312-darwin.so
       0x16a628000 -        0x16a62bfff _multiprocessing.cpython-312-darwin.so (*) <de42d43d-4bcf-32f5-b306-b903b5515122> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/_multiprocessing.cpython-312-darwin.so
       0x16a610000 -        0x16a617fff cmath.cpython-312-darwin.so (*) <28b80fc0-c0d5-3416-a313-3ef6c56c3d8f> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/cmath.cpython-312-darwin.so
       0x13faec000 -        0x13faeffff mmap.cpython-312-darwin.so (*) <d3657bc8-7dc1-367f-84f4-dbbeb7ee5e0c> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/mmap.cpython-312-darwin.so
       0x13fad8000 -        0x13fadbfff grp.cpython-312-darwin.so (*) <60884891-a402-3c45-8691-9343bb994b0a> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/grp.cpython-312-darwin.so
       0x13e82c000 -        0x13e82ffff _heapq.cpython-312-darwin.so (*) <5059d89b-9c2e-3213-bf7d-01b3b7516c8f> /opt/homebrew/*/Python.framework/Versions/3.12/lib/python3.12/lib-dynload/_heapq.cpython-312-darwin.so
       0x12d1f0000 -        0x12d1f3fff _C.cpython-312-darwin.so (*) <385c2dc6-169c-3ebc-b8be-a30c701ebc19> /opt/homebrew/*/_C.cpython-312-darwin.so
       0x2f7a40000 -        0x2f87cbfff libtorch_python.dylib (*) <d0e6b888-e826-39d3-ac97-3fdec7e3b612> /opt/homebrew/*/libtorch_python.dylib
```