### PR TITLE
Integration of measures for models not supporting FP16

### DIFF
--- a/audio_processing/bert-vits2/bert-vits2.py
+++ b/audio_processing/bert-vits2/bert-vits2.py
@@ -27,7 +27,7 @@ from scipy.io.wavfile import write
 DEFAULT_INPUT = '吾輩は猫である'
 DEFAULT_EMO = "私はいまとても嬉しいです"
 DEFAULT_OUTPUT = 'result.wav'
-parser = get_base_parser('Bert-VITS2', None, DEFAULT_OUTPUT)
+parser = get_base_parser('Bert-VITS2', None, DEFAULT_OUTPUT, fp16_support=False)
 
 parser.add_argument(
     '--text',
@@ -316,11 +316,6 @@ def main():
         bert_tokenizer = ailia_tokenizer.BertJapaneseCharacterTokenizer.from_pretrained(dict_path = 'unidic-lite', pretrained_model_name_or_path = "./tokenizer/deberta-v2-large-japanese-char-wwm")
         clap_tokenizer = ailia_tokenizer.RobertaTokenizer.from_pretrained('./tokenizer/clap-htsat-fused')
     models = {'bert_tokenizer': bert_tokenizer,'clap_tokenizer': clap_tokenizer}
-
-    #disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.error('This model do not work on FP16, use CPU instead.')
-        args.env_id = 0
 
     for m in MODEL_NAMES:
         check_and_download_models(

--- a/audio_processing/narabas/narabas.py
+++ b/audio_processing/narabas/narabas.py
@@ -26,7 +26,7 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/narabas/"
 AUDIO_PATH = "input.wav"
 HOP_LENGTH_SEC = 0.02
 
-parser = get_base_parser('narabas', AUDIO_PATH, None)
+parser = get_base_parser('narabas', AUDIO_PATH, None fp16_support=False)
 parser.add_argument(
     '--onnx',
     action='store_true',
@@ -140,11 +140,6 @@ def infer(net: Union[ailia.Net, onnxruntime.InferenceSession]):
 
 
 if __name__ == "__main__":
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
-
     check_and_download_models(NARABAS_WEIGHT_PASS, NARABAS_MODEL_PATH, REMOTE_PATH)
     net = create_instance(NARABAS_WEIGHT_PASS, NARABAS_MODEL_PATH)
     infer(net)

--- a/audio_processing/pytorch-dc-tts/pytorch-dc-tts.py
+++ b/audio_processing/pytorch-dc-tts/pytorch-dc-tts.py
@@ -37,7 +37,7 @@ MAX_T = 210
 # ======================
 
 parser = get_base_parser( 'Efficiently Trainable Text-to-Speech System Based on' +
-    'Deep Convolutional Networks with Guided Attention', SENTENCE, SAVE_WAV_PATH)
+    'Deep Convolutional Networks with Guided Attention', SENTENCE, SAVE_WAV_PATH, fp16_support=False)
 # overwrite
 parser.add_argument(
     '--input', '-i', metavar='TEXT', default=SENTENCE,
@@ -121,11 +121,6 @@ def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH_T2M, MODEL_PATH_T2M, REMOTE_PATH_T2M)
     check_and_download_models(WEIGHT_PATH_SSRM, MODEL_PATH_SSRM, REMOTE_PATH_SSRM)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     generate_sentence(args.input)
 

--- a/audio_processing/silero-vad/silero-vad.py
+++ b/audio_processing/silero-vad/silero-vad.py
@@ -44,7 +44,7 @@ SAMPLING_RATE = 16000
 # ======================
 
 parser = get_base_parser(
-    'Silero VAD', WAVE_PATH, SAVE_PATH, input_ftype='audio'
+    'Silero VAD', WAVE_PATH, SAVE_PATH, input_ftype='audio', fp16_support=False
 )
 parser.add_argument(
     '--onnx',
@@ -111,11 +111,6 @@ def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
     
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
-        
     if not args.onnx:
         env_id = args.env_id
         session = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)

--- a/background_removal/deep-image-matting/deep-image-matting.py
+++ b/background_removal/deep-image-matting/deep-image-matting.py
@@ -38,7 +38,7 @@ FRAMEWORK_LISTS = ['keras', 'torch']
 # ======================
 # Arguemnt Parser Config
 # ======================
-parser = get_base_parser('Deep Image Matting', IMAGE_PATH, SAVE_IMAGE_PATH)
+parser = get_base_parser('Deep Image Matting', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False)
 parser.add_argument(
     '-t', '--trimap', metavar='IMAGE',
     default=TRIMAP_PATH,
@@ -424,12 +424,11 @@ def main():
     )
 
     # net initialize
-    env_id = 0  # use cpu because overflow fp16 range
     if args.onnx:
         import onnxruntime
         net = onnxruntime.InferenceSession(WEIGHT_PATH)
     else:
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
 
     if args.video is not None:
         # video mode

--- a/diffusion/riffusion/riffusion.py
+++ b/diffusion/riffusion/riffusion.py
@@ -43,7 +43,7 @@ SAVE_WAV_PATH = 'output.wav'
 # ======================
 
 parser = get_base_parser(
-    'Riffusion', None, SAVE_WAV_PATH
+    'Riffusion', None, SAVE_WAV_PATH, fp16_support=False
 )
 parser.add_argument(
     "-i", "--input", metavar="TEXT", type=str,
@@ -363,10 +363,6 @@ def main():
 
     env_id = args.env_id
 
-    # warning FP16
-    if "FP16" in ailia.get_environment(args.env_id).props:
-        logger.warning('FP32 is recommended for this model.')
-    
     # initialize
     if not args.onnx:
         memory_mode = ailia.get_memory_mode(

--- a/diffusion/sdxl-turbo/sdxl-turbo.py
+++ b/diffusion/sdxl-turbo/sdxl-turbo.py
@@ -44,7 +44,7 @@ SAVE_IMAGE_PATH = "output.png"
 # Arguemnt Parser Config
 # ======================
 
-parser = get_base_parser("SDXL-Turbo", None, SAVE_IMAGE_PATH)
+parser = get_base_parser("SDXL-Turbo", None, SAVE_IMAGE_PATH, fp16_support=False)
 parser.add_argument(
     "-i",
     "--input",
@@ -145,11 +145,6 @@ def main():
         np.random.seed(seed)
 
     env_id = args.env_id
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # initialize
     if not args.onnx:

--- a/face_recognition/mivolo/mivolo.py
+++ b/face_recognition/mivolo/mivolo.py
@@ -41,6 +41,7 @@ parser = get_base_parser(
     'MiVOLO: Multi-input Transformer for Age and Gender Estimation',
     IMAGE_OR_VIDEO_PATH,
     SAVE_IMAGE_OR_VIDEO_PATH,
+    fp16_support=False
 )
 parser.add_argument(
     '-ng', '--no_gender', action='store_true',
@@ -609,11 +610,6 @@ def main():
     # model files check and download
     check_and_download_models(WEIGHT_YOLOV8_PATH, MODEL_YOLOV8_PATH, REMOTE_PATH)
     check_and_download_models(WEIGHT_MIVOLO_PATH, MODEL_MIVOLO_PATH, REMOTE_PATH)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # net initialize
     logger.info(f'env_id: {args.env_id}')

--- a/face_restoration/gfpgan/gfpgan.py
+++ b/face_restoration/gfpgan/gfpgan.py
@@ -42,7 +42,7 @@ IMAGE_SIZE = 512
 # ======================
 
 parser = get_base_parser(
-    'GFPGAN', IMAGE_PATH, SAVE_IMAGE_PATH
+    'GFPGAN', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-u', '--upscale', type=int, default=1,
@@ -250,11 +250,6 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
     if not args.aligned and not args.facexlib:
         check_and_download_models(WEIGHT_DET_PATH, MODEL_DET_PATH, REMOTE_PATH)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     env_id = args.env_id
 

--- a/frame_interpolation/cain/cain.py
+++ b/frame_interpolation/cain/cain.py
@@ -35,7 +35,7 @@ SAVE_IMAGE_PATH = 'output.png'
 # Arguemnt Parser Config
 # ======================
 
-parser = get_base_parser('CAIN', IMAGE_PATH, SAVE_IMAGE_PATH)
+parser = get_base_parser('CAIN', IMAGE_PATH, SAVE_IMAGE_PATH, large_model=True)
 parser.add_argument(
     '-i2', '--input2', metavar='IMAGE2', default=None,
     help='The second input image path.'
@@ -45,7 +45,7 @@ parser.add_argument(
     default="256,448",
     help='Specify the size to resize on video mode.'
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 # ======================

--- a/frame_interpolation/flavr/flavr.py
+++ b/frame_interpolation/flavr/flavr.py
@@ -38,7 +38,7 @@ SAVE_IMAGE_PATH = 'output.png'
 # ======================
 # Arguemnt Parser Config
 # ======================
-parser = get_base_parser('FLAVR model', IMAGE_PATH, SAVE_IMAGE_PATH)
+parser = get_base_parser('FLAVR model', IMAGE_PATH, SAVE_IMAGE_PATH, large_model=True)
 parser.add_argument(
     '-ip', '--interpolation', type=int, choices=(2, 4, 8), default=2,
     help='2x/4x/8x Interpolation'
@@ -53,7 +53,7 @@ parser.add_argument(
     default="256,448",
     help='Specify the size to resize.'
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 # ======================

--- a/image_captioning/blip2/blip2.py
+++ b/image_captioning/blip2/blip2.py
@@ -49,7 +49,7 @@ parser.add_argument(
     action='store_true',
     help='disable ailia tokenizer.'
 )
-args = update_parser(parser, check_input_type=False)
+args = update_parser(parser, check_input_type=False, fp16_support=False)
 
 
 # ======================
@@ -355,11 +355,7 @@ def main():
     check_and_download_file(WEIGHT_PB_PATH, REMOTE_PATH)
     check_and_download_file(WEIGHT_VIS_PB_PATH, REMOTE_PATH)
 
-    # disable FP16
     env_id = args.env_id
-    if "FP16" in ailia.get_environment(env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # initialize
     if not args.onnx:

--- a/image_classification/clip/clip.py
+++ b/image_classification/clip/clip.py
@@ -52,7 +52,7 @@ IMAGE_SIZE = 224
 # ======================
 
 parser = get_base_parser(
-    'CLIP', IMAGE_PATH, SAVE_IMAGE_PATH
+    'CLIP', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-t', '--text', dest='text_inputs', type=str,
@@ -295,11 +295,6 @@ def main():
     check_and_download_models(WEIGHT_TEXT_PATH, MODEL_TEXT_PATH, REMOTE_PATH)
 
     env_id = args.env_id
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # initialize
     if not args.onnx:

--- a/image_classification/convnext/convnext.py
+++ b/image_classification/convnext/convnext.py
@@ -33,7 +33,7 @@ IMAGE_WIDTH = 32
 # ======================
 # Argument Parser Config
 # ======================
-parser = get_base_parser("ConvNeXt is ", IMAGE_PATH, None,)
+parser = get_base_parser("ConvNeXt is ", IMAGE_PATH, None, fp16_support=False)
 parser.add_argument('-m', '--model', metavar='MODEL',
                     default="base_1k", choices=['base_1k', 'small_1k', 'tiny_1k', 'cifar10'])
 args = update_parser(parser)
@@ -137,10 +137,6 @@ def recognize_from_video(net, classes):
     logger.info('Script finished successfully.')
 
 def main():
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
-
     if args.model == 'base_1k':
         # model files check and download
         check_and_download_models(BASE_1k_WEIGHT_PATH, BASE_1k_MODEL_PATH, REMOTE_PATH)

--- a/image_classification/imagenet21k/imagenet21k.py
+++ b/image_classification/imagenet21k/imagenet21k.py
@@ -39,7 +39,7 @@ MODEL_LISTS = ['resnet50','mixer','vit','mobilenet']
 # Arguemnt Parser Config
 # ======================
 parser = get_base_parser(
-    'imagenet21k', IMAGE_PATH, None
+    'imagenet21k', IMAGE_PATH, None, fp16_support=False
 )
 
 parser.add_argument(
@@ -262,10 +262,6 @@ def main():
 
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
-
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # net initialize
     net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)

--- a/image_classification/vit/vit.py
+++ b/image_classification/vit/vit.py
@@ -42,6 +42,7 @@ parser = get_base_parser(
     'Vision Transformer',
     IMAGE_OR_VIDEO_PATH,
     SAVE_IMAGE_OR_VIDEO_PATH,
+    fp16_support=False
 )
 parser.add_argument(
     '-m', '--model', metavar='MODEL',
@@ -268,10 +269,6 @@ def recognize_from_video():
 def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
-
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     if args.video is not None:
         # video mode

--- a/image_inpainting/deepfillv2/deepfillv2.py
+++ b/image_inpainting/deepfillv2/deepfillv2.py
@@ -46,7 +46,7 @@ SAVE_IMAGE_PATH = 'result.png'
 # ======================
 # Arguemnt Parser Config
 # ======================
-parser = get_base_parser('deepfillv2 model', IMAGE_PATH, SAVE_IMAGE_PATH)
+parser = get_base_parser('deepfillv2 model', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False)
 parser.add_argument(
     '-m', '--model', default="places", choices=("places", "celeba"),
     help='mask type'
@@ -184,10 +184,6 @@ def main():
                     "\t(MODEL = celeba, IMG_RESOLUTION = 256)\n"
                     "\t(MODEL = places, IMG_RESOLUTION = 256 or 512 or 1024)")
         sys.exit(-1)
-
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # model files check and download
     weight_path, model_path, img_shape = info[key]

--- a/image_manipulation/cnngeometric_pytorch/cnngeometric_pytorch.py
+++ b/image_manipulation/cnngeometric_pytorch/cnngeometric_pytorch.py
@@ -47,7 +47,7 @@ IMAGE_HEIGHT = 240
 # Arguemnt Parser Config
 # ======================
 parser = get_base_parser(
-    'CNNGeometric PyTorch', SOURCE_IMAGE_PATH, SAVE_IMAGE_PATH
+    'CNNGeometric PyTorch', SOURCE_IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-m', '--model_1', default='streetview_affine', choices=('streetview_affine', 'streetview_hom', 'streetview_tps'),
@@ -229,11 +229,6 @@ def main():
     check_and_download_models(WEIGHT_STREETVIEW_AFFINE_PATH, MODEL_STREETVIEW_AFFINE_PATH, REMOTE_PATH)
     check_and_download_models(WEIGHT_STREETVIEW_HOM_PATH, MODEL_STREETVIEW_HOM_PATH, REMOTE_PATH)
     check_and_download_models(WEIGHT_STREETVIEW_TPS_PATH, MODEL_STREETVIEW_TPS_PATH, REMOTE_PATH)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # net initialize
     if args.model_1 == 'streetview_affine':

--- a/image_manipulation/dehamer/dehamer.py
+++ b/image_manipulation/dehamer/dehamer.py
@@ -44,7 +44,7 @@ IMAGE_MAX_SIZE = 960
 # ======================
 
 parser = get_base_parser(
-    'Dehamer', IMAGE_PATH, SAVE_IMAGE_PATH
+    'Dehamer', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-m', '--model_type', default='NH', choices=('NH', 'dense', 'indoor', 'outdoor'),
@@ -217,10 +217,6 @@ def main():
 
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
-
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # initialize
     if not args.onnx:

--- a/image_manipulation/lightglue/lightglue.py
+++ b/image_manipulation/lightglue/lightglue.py
@@ -40,7 +40,7 @@ SAVE_IMAGE_PATH = 'output.png'
 # ======================
 
 parser = get_base_parser(
-    'LightGlue', IMAGE_A_PATH, SAVE_IMAGE_PATH
+    'LightGlue', IMAGE_A_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-i2', '--input2', metavar='IMAGE2', default=IMAGE_B_PATH,
@@ -153,11 +153,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
     check_and_download_models(LIGHTGLUE_WEIGHT_PATH, LIGHTGLUE_MODEL_PATH, REMOTE_PATH)
 
-    # disable FP16
     env_id = args.env_id
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # Load ONNX models
 

--- a/image_manipulation/style2paints/style2paints.py
+++ b/image_manipulation/style2paints/style2paints.py
@@ -48,9 +48,9 @@ SAVE_IMAGE_PATH = 'output.png'
 # ======================
 
 parser = get_base_parser(
-    'Style2Paints model', IMAGE_PATH, SAVE_IMAGE_PATH
+    'Style2Paints model', IMAGE_PATH, SAVE_IMAGE_PATH, large_model=True
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 

--- a/image_restoration/nafnet/nafnet.py
+++ b/image_restoration/nafnet/nafnet.py
@@ -37,7 +37,7 @@ MODEL_LISTS= BLUR_LISTS + NOISE_LISTS
 # Arguemnt Parser Config
 # ======================
 
-parser = get_base_parser('NAFNet model', IMAGE_PATH, SAVE_IMAGE_PATH)
+parser = get_base_parser('NAFNet model', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False)
 
 parser.add_argument(
     '-a', '--arch', metavar='ARCH',
@@ -180,10 +180,6 @@ def main():
     
     # net initialize
     env_id = args.env_id
-    if args.arch in BLUR_LISTS:
-        if "FP16" in ailia.get_environment(env_id).props:
-            logger.warning('This model do not work on FP16. So use CPU mode.')
-            env_id = 0
 
     memory_mode=ailia.get_memory_mode(True,True,False,True)
     net = ailia.Net(None, WEIGHT_PATH,memory_mode=memory_mode,env_id=env_id)

--- a/image_segmentation/segment-anything/segment-anything.py
+++ b/image_segmentation/segment-anything/segment-anything.py
@@ -54,7 +54,7 @@ TARGET_LENGTH = 1024
 # ======================
 
 parser = get_base_parser(
-    'Segment Anything', IMAGE_PATH, SAVE_IMAGE_PATH
+    'Segment Anything', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-p', '--pos', action='append', type=int, metavar="X", nargs=2,
@@ -405,11 +405,6 @@ def main():
 
     env_id = args.env_id
 
-    # disable FP16
-    if "FP16" in ailia.get_environment(env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
-    
     # initialize
     if not args.onnx:
         memory_mode = ailia.get_memory_mode(

--- a/image_segmentation/yet-another-anime-segmenter/yet-another-anime-segmenter.py
+++ b/image_segmentation/yet-another-anime-segmenter/yet-another-anime-segmenter.py
@@ -32,7 +32,7 @@ IMAGE_WIDTH = 128
 # Argument Parser Config
 # ======================
 parser = get_base_parser(
-    'Yet-Another-Anime-Segmenter, anime character segmentation.', IMAGE_PATH, SAVE_IMAGE_PATH,
+    'Yet-Another-Anime-Segmenter, anime character segmentation.', IMAGE_PATH, SAVE_IMAGE_PATH, large_model=True
 )
 parser.add_argument(
     '--onnx',
@@ -40,7 +40,7 @@ parser.add_argument(
     help='By default, the ailia SDK is used, but with this option, ' +
     'you can switch to using ONNX Runtime'
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 # ======================

--- a/natural_language_processing/sentence_transformers_japanese/sentence_transformers_japanese.py
+++ b/natural_language_processing/sentence_transformers_japanese/sentence_transformers_japanese.py
@@ -33,7 +33,7 @@ MIN_LENGTH = 5
 # Arguemnt Parser Config
 # ======================
 parser = get_base_parser(
-    'sentence transformers japanese', SAMPLE_PDF_PATH, None 
+    'sentence transformers japanese', SAMPLE_PDF_PATH, None , fp16_support=False
 )
 parser.add_argument(
     '-p', '--prompt', metavar='PROMPT', default=None,
@@ -99,9 +99,6 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
 
     # initialize
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
     model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
 
     if args.disable_ailia_tokenizer:

--- a/natural_language_processing/t5_base_japanese_ner/t5_base_japanese_ner.py
+++ b/natural_language_processing/t5_base_japanese_ner/t5_base_japanese_ner.py
@@ -33,7 +33,7 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/t5_base_japanese_ner/
 # ======================
 
 parser = get_base_parser(
-    't5_base_japanese_summarization', None, None
+    't5_base_japanese_summarization', None, None, fp16_support=False
 )
 
 parser.add_argument(
@@ -145,11 +145,6 @@ def main():
         tokenizer = T5Tokenizer.from_pretrained("./tokenizer/")
 
     env_id = args.env_id
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. Use CPU mode instead.')
-        env_id = 0
 
     # initialize
     encoder = ailia.Net(ENCODER_MODEL_PATH, ENCODER_WEIGHT_PATH, env_id = env_id)

--- a/natural_language_processing/t5_base_japanese_summarization/t5_base_japanese_summarization.py
+++ b/natural_language_processing/t5_base_japanese_summarization/t5_base_japanese_summarization.py
@@ -30,7 +30,7 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/t5_base_japanese_summ
 # ======================
 
 parser = get_base_parser(
-    't5_base_japanese_summarization', None, None
+    't5_base_japanese_summarization', None, None, fp16_support=False
 )
 
 parser.add_argument(
@@ -307,11 +307,6 @@ def main():
         tokenizer = T5Tokenizer.from_pretrained("./tokenizer/")
 
     env_id = args.env_id
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # initialize
     encoder = ailia.Net(ENCODER_MODEL_PATH, ENCODER_WEIGHT_PATH, env_id = env_id)

--- a/network_intrusion_detection/falcon-adapter-network-packet/falcon-adapter-network-packet.py
+++ b/network_intrusion_detection/falcon-adapter-network-packet/falcon-adapter-network-packet.py
@@ -74,6 +74,7 @@ parser = get_base_parser(
     "falcon-adapter-network-packet",
     PACEKT_HEX_PATH,
     None,
+    fp16_support=False
 )
 parser.add_argument("--hex", type=str, default=None, help="Input-HEX data.")
 parser.add_argument(
@@ -544,11 +545,6 @@ def main():
     check_and_download_file(CORPUS_PATH, REMOTE_PATH)
 
     env_id = args.env_id
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # initialize
     if not args.onnx:

--- a/object_detection/detic/detic.py
+++ b/object_detection/detic/detic.py
@@ -54,7 +54,7 @@ SAVE_IMAGE_PATH = 'output.png'
 # ======================
 
 parser = get_base_parser(
-    'Detic', IMAGE_PATH, SAVE_IMAGE_PATH
+    'Detic', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '--seed', type=int, default=int(datetime.datetime.now().strftime('%Y%m%d')),
@@ -481,11 +481,6 @@ def main():
 
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or platform.system() == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     # initialize
     if not args.onnx:

--- a/object_detection/maskrcnn/maskrcnn.py
+++ b/object_detection/maskrcnn/maskrcnn.py
@@ -40,6 +40,7 @@ parser = get_base_parser(
     'Real-time NN for object instance segmentation by Mask R-CNN',
     IMAGE_PATH,
     SAVE_IMAGE_PATH,
+    large_model=True
 )
 parser.add_argument(
     '-n', '--normal',
@@ -47,7 +48,7 @@ parser.add_argument(
     help='By default, the optimized model is used, but with this option, ' +
     'you can switch to the normal (not optimized) model'
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 if args.normal:
     WEIGHT_PATH = 'mask_rcnn_R_50_FPN_1x.onnx'

--- a/object_tracking/deepsort_vehicle/deepsort_vehicle.py
+++ b/object_tracking/deepsort_vehicle/deepsort_vehicle.py
@@ -70,7 +70,7 @@ NN_BUDGET = 100
 # Arguemnt Parser Config
 # ======================
 
-parser = get_base_parser('Deep SORT Vehicle', None, None)
+parser = get_base_parser('Deep SORT Vehicle', None, None, fp16_support=False)
 parser.add_argument(
     '-p', '--pairimage', metavar='IMAGE',
     nargs=2,
@@ -322,11 +322,6 @@ def compare_images(detector, extractor):
 
 
 def main():
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
-
     # model files check and download
     if not args.no_detector:
         logger.info('Check Detector...')

--- a/pose_estimation_3d/3dmppe_posenet/3dmppe_posenet.py
+++ b/pose_estimation_3d/3dmppe_posenet/3dmppe_posenet.py
@@ -60,8 +60,9 @@ parser = get_base_parser(
     'Real-time NN for 3D Multi-person Pose Estimation by PoseNet',
     IMAGE_OR_VIDEO_PATH,
     SAVE_IMAGE_OR_VIDEO_PATH,
+    large_model=True
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 # ======================

--- a/pose_estimation_3d/blazepose-fullbody/blazepose-fullbody.py
+++ b/pose_estimation_3d/blazepose-fullbody/blazepose-fullbody.py
@@ -46,6 +46,7 @@ parser = get_base_parser(
     'BlazePose, an on-device real-time body pose tracking.',
     IMAGE_PATH,
     SAVE_IMAGE_PATH,
+    fp16_support=False
 )
 parser.add_argument(
     '-m', '--model', metavar='ARCH',
@@ -365,11 +366,6 @@ def main():
     }
     weight_path, model_path = info[args.model]
     check_and_download_models(weight_path, model_path, REMOTE_PATH)
-
-    # disable FP16
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        args.env_id = 0
 
     env_id = args.env_id
     

--- a/super_resolution/han/han.py
+++ b/super_resolution/han/han.py
@@ -29,7 +29,7 @@ SAVE_IMAGE_PATH = 'output.png'
 # Argument Parser Config
 # ======================
 parser = get_base_parser(
-    'Single Image Super-Resolution with HAN', IMAGE_PATH, SAVE_IMAGE_PATH,
+    'Single Image Super-Resolution with HAN', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '-n', '--normal', action='store_true',
@@ -205,9 +205,6 @@ def main():
 
     # net initialize
     env_id = args.env_id
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == "darwin" :
-        env_id = 0
-        logger.info('This model not working on FP16. So running on CPU.')
     memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)
     net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=memory_mode)
     logger.info('Model: ' + WEIGHT_PATH[:-5])

--- a/super_resolution/hat/hat.py
+++ b/super_resolution/hat/hat.py
@@ -30,7 +30,7 @@ IMAGE_WIDTH = 256
 # Argument Parser Config
 # ======================
 parser = get_base_parser(
-    'Single Image Super-Resolution with HAT', IMAGE_PATH, SAVE_IMAGE_PATH,
+    'Single Image Super-Resolution with HAT', IMAGE_PATH, SAVE_IMAGE_PATH, fp16_support=False
 )
 parser.add_argument(
     '--arch', default="HAT", type=str, choices=["HAT","HAT_S","HAT_GAN_REAL_sharper","HAT_GAN_REAL"],
@@ -202,12 +202,6 @@ def recognize_from_video(net):
 def main():
     # model files check and download
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
-
-    # disable FP16
-    env_id = args.env_id
-    if "FP16" in ailia.get_environment(args.env_id).props or sys.platform == 'Darwin':
-        logger.warning('This model do not work on FP16. So use CPU mode.')
-        env_id = 0
 
     # net initialize
     memory_mode = ailia.get_memory_mode(reduce_constant=True, reduce_interstage=True)

--- a/super_resolution/swinir/swinir.py
+++ b/super_resolution/swinir/swinir.py
@@ -57,7 +57,7 @@ REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/swinir/'
 # ======================
 
 parser = get_base_parser(
-    'SwinIR: Image Restoration Using Swin Transformer', IMAGE_CLASSICAL_PATH, SAVE_IMAGE_PATH
+    'SwinIR: Image Restoration Using Swin Transformer', IMAGE_CLASSICAL_PATH, SAVE_IMAGE_PATH, large_model=True
 )
 parser.add_argument(
     '--onnx',
@@ -69,7 +69,7 @@ parser.add_argument(
     default='classical',
     choices=['classical', 'lightweight', 'real', 'gray', 'color', 'jpeg']
 )
-args = update_parser(parser, large_model=True)
+args = update_parser(parser)
 
 
 # ======================


### PR DESCRIPTION
- モデルごとに実装していたFP16非対応モデルをFP32のbackendに置換する処理を統合
- base_parserの引数にsupport_fp16とlarge_modelの引数を追加し、これらが有効であればBLASにフォールバックする
- env_idを明示的に指定した場合は、FP16非対応モデルであっても実行を許容
#1581 

懸念点は、モデルテストにおいて、従来はFP16非対応モデルにFP16のEnvironmentを与えた場合、強制的にCPUに変換されて実行されていたが、このPRをマージすると、非対応モデルもGPUで実行される。そのため、モデルテストで不一致が発生する可能性がある。

FP16非対応モデルの場合にはenv_idが指定されていても強制的にCPUで実行するオプションをテスト用に追加する必要があるかも？