### PR TITLE
fix depth_anything model url

### DIFF
--- a/depth_estimation/depth_anything/depth_anything.py
+++ b/depth_estimation/depth_anything/depth_anything.py
@@ -28,10 +28,10 @@ logger = getLogger(__name__)
 WEIGHT_PATH_S = "depth_anything_vits14.onnx"
 MODEL_PATH_S = "depth_anything_vits14.onnx.prototxt"
 
-WEIGHT_PATH_B = "onnx_repo_safe/depth_anything_vitb14.onnx"
+WEIGHT_PATH_B = "depth_anything_vitb14.onnx"
 MODEL_PATH_B = "depth_anything_vitb14.onnx.prototxt"
 
-WEIGHT_PATH_L = "onnx_repo_safe/depth_anything_vitl14.onnx"
+WEIGHT_PATH_L = "depth_anything_vitl14.onnx"
 MODEL_PATH_L = "depth_anything_vitl14.onnx.prototxt"
 
 REMOTE_PATH = "https://storage.googleapis.com/ailia-models/depth_anything/"


### PR DESCRIPTION
depth_anything の vitb, vitl の場合のモデルのダウンロードに失敗したため URL を修正しました。