### PR TITLE
add onnx option to gfpgan

### DIFF
--- a/face_restoration/gfpgan/face_restoration.py
+++ b/face_restoration/gfpgan/face_restoration.py
@@ -80,7 +80,7 @@ def detect_faces(
         image,
         conf_threshold=0.8,
         nms_threshold=0.4):
-    image = image - np.array([104., 117., 123.])
+    image = image - np.array([104., 117., 123.], dtype=np.float32)
     image = image.transpose(2, 0, 1)
     image = np.expand_dims(image, axis=0)
     height, width = image.shape[2:]

--- a/face_restoration/gfpgan/gfpgan.py
+++ b/face_restoration/gfpgan/gfpgan.py
@@ -295,7 +295,7 @@ def main():
                 device=device)
             models["face_restor"] = face_restor
         else:
-            # assert not args.onnx, "face_det is currently not supporting onnx option"
+            assert not args.onnx, "onnx option not supported for face_det"
 
             face_det = ailia.Net(MODEL_DET_PATH, WEIGHT_DET_PATH, env_id=env_id)
             models["face_det"] = face_det

--- a/face_restoration/gfpgan/gfpgan.py
+++ b/face_restoration/gfpgan/gfpgan.py
@@ -65,6 +65,11 @@ parser.add_argument(
     default='v1.3',
     help=['v1.3', 'v1.4']
 )
+parser.add_argument(
+    '--onnx',
+    action='store_true',
+    help='execute onnxruntime version.'
+)
 args = update_parser(parser)
 
 
@@ -135,7 +140,10 @@ def predict(models, img):
         x = preprocess(cropped_face)
 
         # feedforward
-        output = gfpgan.predict([x])
+        if not args.onnx:
+            output = gfpgan.predict([x])
+        else:
+            output = gfpgan.run(None, {'x': x})
         pred = output[0]
 
         restored_face = post_processing(pred)
@@ -254,7 +262,18 @@ def main():
     env_id = args.env_id
 
     # initialize
-    gfpgan = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+    if not args.onnx:
+        gfpgan = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+    else:
+        import onnxruntime
+        available_providers = onnxruntime.get_available_providers()
+        if 'CUDAExecutionProvider' in available_providers:
+            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        elif 'DmlExecutionProvider' in available_providers:
+            providers = ['DmlExecutionProvider', 'CPUExecutionProvider']
+        else:
+            providers = ['CPUExecutionProvider']
+        gfpgan = onnxruntime.InferenceSession(WEIGHT_PATH, providers=providers)
 
     models = {
         "gfpgan": gfpgan,
@@ -276,6 +295,8 @@ def main():
                 device=device)
             models["face_restor"] = face_restor
         else:
+            # assert not args.onnx, "face_det is currently not supporting onnx option"
+
             face_det = ailia.Net(MODEL_DET_PATH, WEIGHT_DET_PATH, env_id=env_id)
             models["face_det"] = face_det
 


### PR DESCRIPTION
onnx optionをgfpganで使えるようにするPR

face_detはモデルファイルの出力形状がおかしいためdirect ml providerで推論できない問題があるのでface_detを使うときか--onnxが指定され場合にエラーを返すようにしてあります

```
C:\Users\k-hayashi\Desktop\work\ailia3\ailia\jenkins\ailia-models-github\face_restoration\gfpgan>python gfpgan.py -b --onnx
 INFO arg_utils.py (13) : Start!
 INFO arg_utils.py (163) : env_id: 2
 INFO arg_utils.py (166) : cuDNN-NVIDIA GeForce RTX 4060 Ti (8.9, FP32)
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
Traceback (most recent call last):
  File "C:\Users\k-hayashi\Desktop\work\ailia3\ailia\jenkins\ailia-models-github\face_restoration\gfpgan\gfpgan.py", line 326, in <module>
    main()
  File "C:\Users\k-hayashi\Desktop\work\ailia3\ailia\jenkins\ailia-models-github\face_restoration\gfpgan\gfpgan.py", line 298, in main
    assert not args.onnx, "onnx option not supported for face_det"
AssertionError: onnx option not supported for face_det
```

onnx optionなしの場合は問題なく動くことを確認済みです
```
C:\Users\k-hayashi\Desktop\work\ailia3\ailia\jenkins\ailia-models-github\face_restoration\gfpgan>python gfpgan.py -b
 INFO arg_utils.py (13) : Start!
 INFO arg_utils.py (163) : env_id: 2
 INFO arg_utils.py (166) : cuDNN-NVIDIA GeForce RTX 4060 Ti (8.9, FP32)
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
 INFO model_utils.py (89) : ONNX file and Prototxt file are prepared!
 INFO license.py (81) : ailiaへようこそ。ailia SDKは商用ライブラリです。特定の条件下では、無償使用いただけますが、原則として有償ソフトウェアです。詳細は https://ailia.ai/license/ を参照してください。
 INFO gfpgan.py (180) : demo.png
 INFO gfpgan.py (187) : Start inference...
 INFO gfpgan.py (189) : BENCHMARK mode
 INFO gfpgan.py (198) :         ailia processing estimation time 2409 ms
 INFO gfpgan.py (198) :         ailia processing estimation time 362 ms
 INFO gfpgan.py (198) :         ailia processing estimation time 335 ms
 INFO gfpgan.py (198) :         ailia processing estimation time 329 ms
 INFO gfpgan.py (198) :         ailia processing estimation time 333 ms
 INFO gfpgan.py (202) :         average time estimation 339.75 ms
 INFO gfpgan.py (208) : saved at : output.png
 INFO gfpgan.py (211) : Script finished successfully.
```