### PR TITLE
update l2cs_net

### DIFF
--- a/face_recognition/l2cs_net/l2cs_util.py
+++ b/face_recognition/l2cs_net/l2cs_util.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 from dataclasses import dataclass
 
-sys.path.append('../../face_detection/retinaface')
+sys.path.insert(0, '../../face_detection/retinaface')
 from retinaface import postprocessing
 import retinaface_utils as rut
 


### PR DESCRIPTION
face_recognition/gazelle では `--face_detect_arch retina-face` オプションを指定する場合 retina-face パッケージが必要となっています。
このために retina-face パッケージがインストール済みの環境では、l2cs_net が本リポジトリの retinaface のコードの一部を import しようとした際に、retina-face パッケージの方を import してエラーとなってしまいます。
そのため、`sys.path` へのパスの追加位置を変更して、l2cs_net が retinaface を import した時に本リポジトリの retinaface が先に見つかるようにしました。