### PR TITLE
fix candidate_labels

### DIFF
--- a/natural_language_processing/multilingual-minilmv2/multilingual-minilmv2.py
+++ b/natural_language_processing/multilingual-minilmv2/multilingual-minilmv2.py
@@ -92,7 +92,7 @@ def main():
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
     ailia_model = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=args.env_id)
 
-    candidate_labels = re.split(r'\s*,\s*', CANDIDATE_LABELS) # Delete spaces before and after commas
+    candidate_labels = re.split(r'\s*,\s*', args.candidate_labels) # Delete spaces before and after commas
 
     if args.disable_ailia_tokenizer:
         from transformers import AutoTokenizer


### PR DESCRIPTION
以下の修正です。
```
multilingual-minilmv2 に含まれるサンプルのスクリプト multilingual-minilmv2.py ですが、引数でカテゴリを指定することができませんでした。
原因は、引数で指定したcandidate_labelsが設定されていないためでした。
```