### PR TITLE
gpt-sovits2のwindowsでcp932エラーになる問題を修正

### DIFF
--- a/audio_processing/gpt-sovits-v2/text/english.py
+++ b/audio_processing/gpt-sovits-v2/text/english.py
@@ -146,7 +146,7 @@ def read_dict():
 
 def read_dict_new():
     g2p_dict = {}
-    with open(CMU_DICT_PATH) as f:
+    with open(CMU_DICT_PATH, encoding="utf-8") as f:
         line = f.readline()
         line_index = 1
         while line:
@@ -159,7 +159,7 @@ def read_dict_new():
             line_index = line_index + 1
             line = f.readline()
 
-    with open(CMU_DICT_FAST_PATH) as f:
+    with open(CMU_DICT_FAST_PATH, encoding="utf-8") as f:
         line = f.readline()
         line_index = 1
         while line:


### PR DESCRIPTION
--ref_language enに指定するとwindowsでcp932エラーになる問題を修正します。

```
  File "E:\git\ailia-models\audio_processing\gpt-sovits-v2\text\english.py", line 207, in get_dict
    g2p_dict = read_dict_new()
  File "E:\git\ailia-models\audio_processing\gpt-sovits-v2\text\english.py", line 160, in read_dict_new
    line = f.readline()
UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 3909: illegal multibyte sequence
```