### PR TITLE
Update pytorch-inpainting-with-partial-conv

### DIFF
--- a/image_inpainting/pytorch-inpainting-with-partial-conv/pytorch-inpainting-with-partial-conv.py
+++ b/image_inpainting/pytorch-inpainting-with-partial-conv/pytorch-inpainting-with-partial-conv.py
@@ -63,7 +63,7 @@ def postprocess(x):
 
 
 def recognize_from_image(net):
-    mask_paths = glob.glob('masks/*.jpg')
+    mask_paths = sorted(glob.glob('masks/*.jpg'))
     N_mask = len(mask_paths)
 
     # input image loop


### PR DESCRIPTION
pytorch-inpainting-with-partial-conv では `--mask-index` オプションで `masks` ディレクトリ内に置かれているマスクを選択できます。しかし、`glob.glob()` の結果が OS によって違う場合があるため、`--mask-index` オプションに同じ値を与えても、実行環境が異なると結果が一致しないことがありました。 これに対処するため `glob.glob()` の結果をソートするようにしました。