### PR TITLE
fix name error for kotoba whisper

### DIFF
--- a/audio_processing/kotoba-whisper/kotoba-whisper.py
+++ b/audio_processing/kotoba-whisper/kotoba-whisper.py
@@ -632,7 +632,8 @@ def predict(models, audio, chunk_length_s=0):
             model_outputs,
             return_timestamps=True,
             return_language=None,
-            time_precision=time_precision)
+            time_precision=time_precision,
+            logger=logger)
 
     return {"text": text, **optional}
 

--- a/audio_processing/kotoba-whisper/tokenizer_utils.py
+++ b/audio_processing/kotoba-whisper/tokenizer_utils.py
@@ -388,7 +388,7 @@ def _merge_punctuations(words, tokens, indices, prepended, appended):
     tokens[:] = [token for token in tokens if token]
     indices[:] = [idx for idx in indices if idx]
 
-def decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language, time_precision):
+def decode_asr(tokenizer, model_outputs, *, return_timestamps, return_language, time_precision, logger):
     """
     Internal method meant to only be used by asr pipeline. Handles all the little quirks specific to whisper to handle
     the various options not allowed in other seq2seq models


### PR DESCRIPTION
Added logger parameter to decode_asr since it was being used but not provided.

NOTE
In MPS, I got following error.
```
File ".../audio_processing/kotoba-whisper/kotoba-whisper.py", line 630, in predict
  text, optional = decode_asr(
File ".../audio_processing/kotoba-whisper/tokenizer_utils.py", line 581, in decode_asr
  logger.warning(
NameError: name \'logger\' is not defined
```