### PR TITLE
fix text_recognition/paddleocr_v3

### DIFF
--- a/text_recognition/paddleocr_v3/paddleocr_v3.py
+++ b/text_recognition/paddleocr_v3/paddleocr_v3.py
@@ -475,9 +475,9 @@ class DBPostProcess(object):
         # calculate circle coordinates
         pitch = 10
         x_upper = np.cos(np.arange(1, 0, (-1 / pitch)) * np.pi) * distance
-        y_upper = -np.sqrt(distance ** 2 - x_upper ** 2)
+        y_upper = -np.sqrt(np.abs(distance ** 2 - x_upper ** 2))
         x_lower = np.cos(np.arange(0, 1, (1 / pitch)) * np.pi) * distance
-        y_lower = np.sqrt(distance ** 2 - x_lower ** 2)
+        y_lower = np.sqrt(np.abs(distance ** 2 - x_lower ** 2))
         x = np.concatenate([x_upper, x_lower])
         y = np.concatenate([y_upper, y_lower])
         circle = np.concatenate([x[:, np.newaxis], y[:, np.newaxis]], axis=1)


### PR DESCRIPTION
text_recognition/paddleocr_v3 の座標計算処理中の減算の結果を `np.sqrt()` に渡している箇所で、浮動小数の誤差のせいか微小な負の値になっている除算の結果に対して `np.sqrt()` を行い NaN が得られ、その後の処理が正しく動かない場合があったため、除算の結果に対して絶対値を取る処理を追加しました。