### PR TITLE
Update object_detection/yolox_body_head_hand_face

### DIFF
--- a/object_detection/yolox_body_head_hand_face/yolox_body_head_hand_face.py
+++ b/object_detection/yolox_body_head_hand_face/yolox_body_head_hand_face.py
@@ -145,21 +145,24 @@ class AbstractModel(ABC):
         env_id: Optional[int] = 0
     ):
         self._env_id = env_id
-        match self._env_id:
-            case 0:
-                providers = ['CPUExecutionProvider']
-            case 2:
-                providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
 
         self._runtime = runtime
         self._model_path = model_path
         self._weight_path = weight_path
         self._class_score_th = class_score_th
-        self._providers = providers
         
         # Model loading
         if self._runtime == 'onnx':
             import onnxruntime # type: ignore
+
+            match self._env_id:
+                case 0:
+                    providers = ['CPUExecutionProvider']
+                case 2:
+                    providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+                case _:
+                    providers = None
+
             session_option = onnxruntime.SessionOptions()
             session_option.log_severity_level = 3
             self._interpreter = \


### PR DESCRIPTION
以下2点の変更を行いました。

- runtime 指定が `onnx` の場合にのみ providers を指定する処理が実行されるように、指定処理を if 文の分岐の中に移動させました。
- 上記指定処理で env_id が match しなかった時に providers 変数が未割り当てのエラーとなったため、match しない場合には `providers = None` とするようにしました。