### PR TITLE
remove `import imghdr` from `object_detection/yolov2-tiny`

### DIFF
--- a/object_detection/yolov2-tiny/yolo_utils.py
+++ b/object_detection/yolov2-tiny/yolo_utils.py
@@ -407,7 +407,7 @@ def get_image_size(fname):
     try:
         with Image.open(fname) as img:
             return img.width, img.height
-    except:
+    except Exception:
         return
 
 def logging(message):


### PR DESCRIPTION
`imghdr` is deprecated scince 3.11, removed in python 3.13. ( https://docs.python.org/ja/3.13/library/imghdr.html )

rewrite `get_image_size()`. and replace `imghdr` with `Pillow`.