### PR TITLE
reduce VRAM requirement (text_recognition/donut)

### DIFF
--- a/text_recognition/donut/donut.py
+++ b/text_recognition/donut/donut.py
@@ -388,8 +388,11 @@ def main():
 
     # initialize
     if not args.onnx:
-        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
-        enc = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id)
+        mem_mode = ailia.get_memory_mode(
+            reduce_constant=True, ignore_input_with_initializer=True,
+            reduce_interstage=False, reuse_interstage=True)
+        net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id, memory_mode=mem_mode)
+        enc = ailia.Net(MODEL_ENC_PATH, WEIGHT_ENC_PATH, env_id=env_id, memory_mode=mem_mode)
     else:
         import onnxruntime
 


### PR DESCRIPTION
reduce ailia memory requirement for `text_recognition/donut` script  ( 13GB -> 4GB ) .