### PR TITLE
keep external pb from `git clean -fd`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ ailia/
 *.caffemodel
 *.onnx
 *.prototxt
+*.pb
 
 __pycache__/
 .ipynb_checkpoints/


### PR DESCRIPTION
## before

`git clean -fd` erases `*.pb` files. 

## after

`git clean -fd` dose not erase `*.pb` files like `*.caffemodel` / `*.onnx` / `*.prototxt` .