### PR TITLE
SenseVoiceにInt4とInt8バージョンを追加

### DIFF
--- a/audio_processing/sensevoice/README.md
+++ b/audio_processing/sensevoice/README.md
@@ -42,6 +42,14 @@ $ python3 sensevoice.py --disable_ailia_audio
 pip3 install kaldi_native_fbank
 ```
 
+By adding the `--quantize` option, you can use int4 or int8 quantized models.
+```bash
+$ python3 sensevoice.py --quantize int4
+$ python3 sensevoice.py --quantize int8
+```
+
+The quantized models are exported using `export/export_quantized.py`.
+
 ## Reference
 
 - [SenseVoice](https://github.com/FunAudioLLM/SenseVoice)

--- a/audio_processing/sensevoice/export/export_quantized.py
+++ b/audio_processing/sensevoice/export/export_quantized.py
@@ -1,0 +1,111 @@
+"""
+Export SenseVoice int4/int8 quantized ONNX models.
+
+Tested versions:
+    onnxruntime 1.24.4
+    onnx 1.20.1
+
+Requirements:
+    pip install onnxruntime onnx numpy
+
+Usage:
+    python export_quantized.py
+    python export_quantized.py --bits 4
+    python export_quantized.py --bits 8
+
+Size reduction:
+  sensevoice_small: 894MB -> 123MB (int4) / 234MB (int8)
+"""
+
+import os
+import sys
+import argparse
+import subprocess
+
+import onnx
+from onnxruntime.quantization.matmul_nbits_quantizer import MatMulNBitsQuantizer
+from onnxruntime.quantization.quant_utils import QuantFormat
+
+
+def download_model(model_name, remote_path):
+    """Download model file from remote storage if not present."""
+    if os.path.exists(model_name):
+        print(f"  {model_name} already exists, skipping download.")
+        return
+    url = remote_path + model_name
+    print(f"  Downloading {model_name} ...")
+    subprocess.check_call(["wget", "-q", url, "-O", model_name])
+
+
+def generate_prototxt(onnx_path):
+    """Generate prototxt from ONNX model using onnx2prototxt.py."""
+    prototxt_path = onnx_path + ".prototxt"
+    script_url = "https://raw.githubusercontent.com/ailia-ai/export-to-onnx/master/onnx2prototxt.py"
+    script_path = "onnx2prototxt.py"
+
+    if not os.path.exists(script_path):
+        print("  Downloading onnx2prototxt.py ...")
+        subprocess.check_call(["wget", "-q", script_url, "-O", script_path])
+
+    print(f"  Generating prototxt for {onnx_path} ...")
+    subprocess.check_call([sys.executable, script_path, onnx_path, prototxt_path])
+    return prototxt_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Export SenseVoice quantized models"
+    )
+    parser.add_argument(
+        "--bits", type=int, default=4, choices=[4, 8],
+        help="Quantization bits (4 or 8, default: 4)",
+    )
+    parser.add_argument(
+        "--output_dir", type=str, default="..",
+        help="Output directory (default: parent dir)",
+    )
+    args = parser.parse_args()
+
+    remote_path = "https://storage.googleapis.com/ailia-models/sensevoice/"
+    work_dir = os.path.abspath(args.output_dir)
+    os.makedirs(work_dir, exist_ok=True)
+    os.chdir(work_dir)
+
+    suffix = f"int{args.bits}"
+    orig = "sensevoice_small.onnx"
+    out = f"sensevoice_small_{suffix}.onnx"
+
+    # Step 1: Download
+    print("[1/3] Downloading original model ...")
+    download_model(orig, remote_path)
+
+    # Step 2: Quantize
+    print(f"[2/3] Quantizing to {suffix} ...")
+    out_path = os.path.join(work_dir, out)
+    quant = MatMulNBitsQuantizer(
+        model=orig, bits=args.bits, block_size=128, is_symmetric=True,
+        accuracy_level=4, quant_format=QuantFormat.QOperator,
+        op_types_to_quantize=("MatMul",),
+    )
+    quant.process()
+
+    result = quant.model.model
+    nbits = sum(1 for n in result.graph.node if n.op_type == "MatMulNBits")
+    print(f"  MatMulNBits nodes created: {nbits}")
+    print(f"  Saving: {out_path}")
+    onnx.save(result, out_path)
+
+    size = os.path.getsize(out_path) / 1024 / 1024
+    print(f"  Output size: {size:.0f}MB")
+
+    # Step 3: Generate prototxt
+    print("[3/3] Generating prototxt ...")
+    prototxt_path = generate_prototxt(out_path)
+
+    print(f"\nDone! Generated files:")
+    print(f"  - {out_path}")
+    print(f"  - {prototxt_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/audio_processing/sensevoice/funasr_ailia/sensevoice_bin.py
+++ b/audio_processing/sensevoice/funasr_ailia/sensevoice_bin.py
@@ -36,6 +36,7 @@ class SenseVoiceSmall:
         ailia_tokenizer: bool = False,
         profile: bool = False,
         model_file = "./sensevoice_small.onnx",
+        disable_optimization: bool = False,
     ):
 
         config_file = "./s2t_config/config.yaml"
@@ -50,7 +51,8 @@ class SenseVoiceSmall:
         self.frontend = WavFrontend(ailia_audio = ailia_audio, **config["frontend_conf"])
         if onnx:
             self.ort_infer = OrtInferSession(
-                model_file, device_id, intra_op_num_threads=intra_op_num_threads
+                model_file, device_id, intra_op_num_threads=intra_op_num_threads,
+                disable_optimization=disable_optimization
             )
         else:
             self.ort_infer = AiliaInferSession(

--- a/audio_processing/sensevoice/funasr_ailia/utils/utils.py
+++ b/audio_processing/sensevoice/funasr_ailia/utils/utils.py
@@ -9,7 +9,7 @@ import yaml
 import warnings
 
 class OrtInferSession:
-    def __init__(self, model_file, device_id=-1, intra_op_num_threads=4):
+    def __init__(self, model_file, device_id=-1, intra_op_num_threads=4, disable_optimization=False):
         from onnxruntime import (
             GraphOptimizationLevel,
             InferenceSession,
@@ -23,7 +23,10 @@ class OrtInferSession:
         sess_opt.intra_op_num_threads = intra_op_num_threads
         sess_opt.log_severity_level = 4
         sess_opt.enable_cpu_mem_arena = False
-        sess_opt.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_ALL
+        if disable_optimization:
+            sess_opt.graph_optimization_level = GraphOptimizationLevel.ORT_DISABLE_ALL
+        else:
+            sess_opt.graph_optimization_level = GraphOptimizationLevel.ORT_ENABLE_ALL
 
         cuda_ep = "CUDAExecutionProvider"
         cuda_provider_options = {

--- a/audio_processing/sensevoice/sensevoice.py
+++ b/audio_processing/sensevoice/sensevoice.py
@@ -49,6 +49,10 @@ parser.add_argument(
 parser.add_argument(
 	"--onnx", action="store_true", help="use onnx runtime."
 )
+parser.add_argument(
+	"--quantize", type=str, default=None, choices=["int4", "int8"],
+	help="use int4 or int8 quantized model.",
+)
 parser.add_argument("--finetuning", type=str, default=None, help="use finetuning model", choices=(None, "japanese"))
 args = update_parser(parser)
 
@@ -68,6 +72,10 @@ else:
 
 MODEL_PATH = WEIGHT_PATH + ".prototxt"
 VAD_MODEL_PATH = VAD_WEIGHT_PATH + ".prototxt"
+
+if args.quantize is not None:
+	WEIGHT_PATH = "sensevoice_small_" + args.quantize + ".onnx"
+	MODEL_PATH = WEIGHT_PATH + ".prototxt"
 
 if args.finetuning is not None:
 	REMOTE_PATH = "https://storage.googleapis.com/ailia-models/sensevoice-finetuning/"
@@ -97,7 +105,7 @@ def recognize_from_audio():
 	for audio_path in args.input:
 		logger.info(audio_path)
 
-		model = SenseVoiceSmall(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, ailia_tokenizer=not args.disable_ailia_tokenizer, profile=args.profile, model_file=WEIGHT_PATH)
+		model = SenseVoiceSmall(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, ailia_tokenizer=not args.disable_ailia_tokenizer, profile=args.profile, model_file=WEIGHT_PATH, disable_optimization=args.quantize is not None)
 		vad = Fsmn_vad_online(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, profile=args.profile, model_file=VAD_WEIGHT_PATH)
 
 		# vad
@@ -172,7 +180,7 @@ def recognize_from_mic():
 	# input audio loop
 	logger.info("Start inference...")
 
-	model = SenseVoiceSmall(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, ailia_tokenizer=not args.disable_ailia_tokenizer, profile=args.profile, model_file=WEIGHT_PATH)
+	model = SenseVoiceSmall(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, ailia_tokenizer=not args.disable_ailia_tokenizer, profile=args.profile, model_file=WEIGHT_PATH, disable_optimization=args.quantize is not None)
 	vad = Fsmn_vad_online(env_id=args.env_id, onnx=args.onnx, ailia_audio=not args.disable_ailia_audio, profile=args.profile, model_file=VAD_WEIGHT_PATH)
 
 	import sounddevice


### PR DESCRIPTION
Quantize sensevoice_small using MatMulNBitsQuantizer (281 MatMul nodes).

Size reduction:
  sensevoice_small: 894MB -> 123MB (int4) / 234MB (int8)

Benchmark (CPU, onnxruntime 1.24.4, 100 frames):
  fp32: 187ms, int4: 175ms, int8: 170ms

Recognition results (ja.wav):
  fp32: うちの中学は弁当制で持っていけない場合は50円の学校販売のパンを買う
  int8: (same as fp32)
  int4: うちの中学は弁当制で持って行ない場合は50円の学校販売のパンを買う

Usage: python3 sensevoice.py --quantize int4

https://claude.ai/code/session_01MbfUQepnKf9NEBTc6xby3u