### PR TITLE
Add dynamic shape support to Depth Anything V3 ONNX export

### DIFF
--- a/depth_estimation/depth_anything_v3/export/README.md
+++ b/depth_estimation/depth_anything_v3/export/README.md
@@ -1,0 +1,48 @@
+# Depth Anything V3 ONNX Export
+
+## Usage
+
+```bash
+pip install depth-anything-3 safetensors huggingface_hub onnx
+python export_onnx.py --encoder vits  # or vitb, vitl
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--encoder` | `vits` | Model type: `vits`, `vitb`, `vitl` |
+| `--output` | `da3_{encoder}.onnx` | Output ONNX file path |
+| `--opset` | `17` | ONNX opset version |
+| `--input_height` | `336` | Input image height (must be multiple of 14) |
+| `--input_width` | `504` | Input image width (must be multiple of 14) |
+
+## Dynamic Shape
+
+Exported ONNX models support dynamic shapes for batch, height, and width dimensions:
+
+- Input `image`: `[batch, 3, height, width]`
+- Output `depth`: `[batch, 1, height, width]`
+
+## Note: torch.cartesian_prod patch
+
+`depth_anything_3` package uses `torch.cartesian_prod` in `PositionGetter` (`depth_anything_3/model/dinov2/layers/rope.py`), which is not supported by the ONNX exporter. Before running the export, this must be replaced with an equivalent using `torch.meshgrid` + `torch.stack`.
+
+Apply the following patch to the installed package before export:
+
+```python
+# In depth_anything_3/model/dinov2/layers/rope.py
+# PositionGetter.__call__()
+
+# Before (not supported by ONNX):
+positions = torch.cartesian_prod(y_coords, x_coords)
+
+# After (ONNX-compatible):
+grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
+positions = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=-1)
+```
+
+The file to patch is located at:
+```
+<python_site_packages>/depth_anything_3/model/dinov2/layers/rope.py
+```

--- a/depth_estimation/depth_anything_v3/export/README.md
+++ b/depth_estimation/depth_anything_v3/export/README.md
@@ -24,53 +24,143 @@ Exported ONNX models support dynamic shapes for batch, height, and width dimensi
 - Input `image`: `[batch, 3, height, width]`
 - Output `depth`: `[batch, 1, height, width]`
 
-## Note: torch.cartesian_prod patch
+Height and width must be multiples of 14 (patch size).
 
-`depth_anything_3` package uses `torch.cartesian_prod` in `PositionGetter` (`depth_anything_3/model/dinov2/layers/rope.py`), which is not supported by the ONNX exporter. Before running the export, this must be replaced with an equivalent using `torch.meshgrid` + `torch.stack`.
+## Required patches to depth_anything_3 package
 
-Apply the following patch to the installed package before export.
+TorchScript tracing bakes shape-dependent Python operations (`int()`, `float()`, dict caching) as constants. The following 4 patches replace them with tensor operations so that shapes propagate dynamically through the ONNX graph. Apply all patches to the installed `depth_anything_3` package before running the export.
 
-File to patch: `<python_site_packages>/depth_anything_3/model/dinov2/layers/rope.py`
+Base path: `<site-packages>/depth_anything_3/`
 
-### Before (original code)
+---
+
+### Patch 1: PositionGetter (rope.py)
+
+`torch.cartesian_prod` is unsupported by ONNX. Replace with `torch.meshgrid` + `torch.stack`. Also remove dict caching (incompatible with traced shape values).
+
+File: `model/dinov2/layers/rope.py` class `PositionGetter.__call__`
 
 ```python
-class PositionGetter:
-    def __init__(self):
-        self.position_cache: Dict[Tuple[int, int], torch.Tensor] = {}
-
-    def __call__(
-        self, batch_size: int, height: int, width: int, device: torch.device
-    ) -> torch.Tensor:
+# Before
+    def __call__(self, batch_size, height, width, device):
         if (height, width) not in self.position_cache:
             y_coords = torch.arange(height, device=device)
             x_coords = torch.arange(width, device=device)
             positions = torch.cartesian_prod(y_coords, x_coords)
             self.position_cache[height, width] = positions
-
         cached_positions = self.position_cache[height, width]
         return cached_positions.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
+
+# After
+    def __call__(self, batch_size, height, width, device):
+        y_coords = torch.arange(height, device=device)
+        x_coords = torch.arange(width, device=device)
+        grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
+        positions = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=-1)
+        return positions.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
 ```
 
-### After (ONNX-compatible)
+---
+
+### Patch 2: RoPE frequency components (rope.py)
+
+`int(positions.max())` is a data-dependent conversion that becomes a constant. Use `positions.shape[1]` (= H*W >= max(H,W)) as an upper bound instead. Also remove dict caching from `_compute_frequency_components`.
+
+File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
 
 ```python
-class PositionGetter:
-    def __init__(self):
-        self.position_cache: Dict[Tuple[int, int], torch.Tensor] = {}
+# Before (_compute_frequency_components)
+        cache_key = (dim, seq_len, device, dtype)
+        if cache_key not in self.frequency_cache:
+            exponents = torch.arange(0, dim, 2, device=device).float() / dim
+            inv_freq = 1.0 / (self.base_frequency**exponents)
+            positions = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            angles = torch.einsum("i,j->ij", positions, inv_freq)
+            angles = angles.to(dtype)
+            angles = torch.cat((angles, angles), dim=-1)
+            cos_components = angles.cos().to(dtype)
+            sin_components = angles.sin().to(dtype)
+            self.frequency_cache[cache_key] = (cos_components, sin_components)
+        return self.frequency_cache[cache_key]
 
-    def __call__(
-        self, batch_size: int, height: int, width: int, device: torch.device
-    ) -> torch.Tensor:
-        if (height, width) not in self.position_cache:
-            y_coords = torch.arange(height, device=device)
-            x_coords = torch.arange(width, device=device)
-            grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
-            positions = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=-1)
-            self.position_cache[height, width] = positions
-
-        cached_positions = self.position_cache[height, width]
-        return cached_positions.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
+# After (_compute_frequency_components)
+        exponents = torch.arange(0, dim, 2, device=device).float() / dim
+        inv_freq = 1.0 / (self.base_frequency**exponents)
+        positions = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+        angles = torch.einsum("i,j->ij", positions, inv_freq)
+        angles = angles.to(dtype)
+        angles = torch.cat((angles, angles), dim=-1)
+        cos_components = angles.cos().to(dtype)
+        sin_components = angles.sin().to(dtype)
+        return (cos_components, sin_components)
 ```
 
-`torch.cartesian_prod` is not supported by the ONNX opset. `torch.meshgrid` + `torch.stack` produces the same (y, x) coordinate pairs and is fully ONNX-compatible.
+```python
+# Before (forward)
+        max_position = int(positions.max()) + 1
+
+# After (forward)
+        max_position = positions.shape[1]
+```
+
+---
+
+### Patch 3: Position embedding interpolation (vision_transformer.py)
+
+`float()` on shape values bakes scale_factor as a constant. Use `size=(h0, w0)` instead.
+
+File: `model/dinov2/vision_transformer.py` method `interpolate_pos_encoding`
+
+```python
+# Before
+        kwargs = {}
+        if self.interpolate_offset:
+            sx = float(w0 + self.interpolate_offset) / M
+            sy = float(h0 + self.interpolate_offset) / M
+            kwargs["scale_factor"] = (sx, sy)
+        else:
+            kwargs["size"] = (w0, h0)
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed.reshape(1, M, M, dim).permute(0, 3, 1, 2),
+            mode="bicubic",
+            antialias=self.interpolate_antialias,
+            **kwargs,
+        )
+        assert (w0, h0) == patch_pos_embed.shape[-2:]
+
+# After
+        patch_pos_embed = nn.functional.interpolate(
+            patch_pos_embed.reshape(1, M, M, dim).permute(0, 3, 1, 2),
+            size=(h0, w0),
+            mode="bicubic",
+            antialias=self.interpolate_antialias,
+        )
+```
+
+---
+
+### Patch 4: Output size computation (dualdpt.py, head_utils.py)
+
+`int()` on shape arithmetic bakes output dimensions as constants. Use integer division instead.
+
+File: `model/dualdpt.py` method `_forward_impl`
+
+```python
+# Before
+        h_out = int(ph * self.patch_size / self.down_ratio)
+        w_out = int(pw * self.patch_size / self.down_ratio)
+
+# After
+        h_out = ph * self.patch_size // self.down_ratio
+        w_out = pw * self.patch_size // self.down_ratio
+```
+
+File: `model/utils/head_utils.py` function `custom_interpolate`
+
+```python
+# Before
+        size = (int(x.shape[-2] * scale_factor), int(x.shape[-1] * scale_factor))
+
+# After
+        size = (x.shape[-2] * scale_factor, x.shape[-1] * scale_factor)
+```

--- a/depth_estimation/depth_anything_v3/export/README.md
+++ b/depth_estimation/depth_anything_v3/export/README.md
@@ -64,7 +64,7 @@ File: `model/dinov2/layers/rope.py` class `PositionGetter.__call__`
 
 ### Patch 2: RoPE frequency components (rope.py)
 
-`int(positions.max())` is a data-dependent conversion that becomes a constant. Use `positions.shape[1]` (= H*W >= max(H,W)) as an upper bound instead. Also remove dict caching from `_compute_frequency_components`.
+`int(positions.max())` is a data-dependent conversion that becomes a constant. Use a fixed upper bound (1024, supporting up to 14336px images) instead. Also remove dict caching from `_compute_frequency_components`, and replace `torch.cat((angles, angles), dim=-1)` with `angles.repeat(1, 2)` (ailia SDK does not support Concat with the same tensor as both inputs).
 
 File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
 
@@ -77,7 +77,7 @@ File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
             positions = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
             angles = torch.einsum("i,j->ij", positions, inv_freq)
             angles = angles.to(dtype)
-            angles = torch.cat((angles, angles), dim=-1)
+            angles = angles.repeat(1, 2)
             cos_components = angles.cos().to(dtype)
             sin_components = angles.sin().to(dtype)
             self.frequency_cache[cache_key] = (cos_components, sin_components)
@@ -100,7 +100,7 @@ File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
         max_position = int(positions.max()) + 1
 
 # After (forward)
-        max_position = positions.shape[1]
+        max_position = 1024
 ```
 
 ---

--- a/depth_estimation/depth_anything_v3/export/README.md
+++ b/depth_estimation/depth_anything_v3/export/README.md
@@ -28,21 +28,49 @@ Exported ONNX models support dynamic shapes for batch, height, and width dimensi
 
 `depth_anything_3` package uses `torch.cartesian_prod` in `PositionGetter` (`depth_anything_3/model/dinov2/layers/rope.py`), which is not supported by the ONNX exporter. Before running the export, this must be replaced with an equivalent using `torch.meshgrid` + `torch.stack`.
 
-Apply the following patch to the installed package before export:
+Apply the following patch to the installed package before export.
+
+File to patch: `<python_site_packages>/depth_anything_3/model/dinov2/layers/rope.py`
+
+### Before (original code)
 
 ```python
-# In depth_anything_3/model/dinov2/layers/rope.py
-# PositionGetter.__call__()
+class PositionGetter:
+    def __init__(self):
+        self.position_cache: Dict[Tuple[int, int], torch.Tensor] = {}
 
-# Before (not supported by ONNX):
-positions = torch.cartesian_prod(y_coords, x_coords)
+    def __call__(
+        self, batch_size: int, height: int, width: int, device: torch.device
+    ) -> torch.Tensor:
+        if (height, width) not in self.position_cache:
+            y_coords = torch.arange(height, device=device)
+            x_coords = torch.arange(width, device=device)
+            positions = torch.cartesian_prod(y_coords, x_coords)
+            self.position_cache[height, width] = positions
 
-# After (ONNX-compatible):
-grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
-positions = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=-1)
+        cached_positions = self.position_cache[height, width]
+        return cached_positions.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
 ```
 
-The file to patch is located at:
+### After (ONNX-compatible)
+
+```python
+class PositionGetter:
+    def __init__(self):
+        self.position_cache: Dict[Tuple[int, int], torch.Tensor] = {}
+
+    def __call__(
+        self, batch_size: int, height: int, width: int, device: torch.device
+    ) -> torch.Tensor:
+        if (height, width) not in self.position_cache:
+            y_coords = torch.arange(height, device=device)
+            x_coords = torch.arange(width, device=device)
+            grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing='ij')
+            positions = torch.stack([grid_y.flatten(), grid_x.flatten()], dim=-1)
+            self.position_cache[height, width] = positions
+
+        cached_positions = self.position_cache[height, width]
+        return cached_positions.view(1, height * width, 2).expand(batch_size, -1, -1).clone()
 ```
-<python_site_packages>/depth_anything_3/model/dinov2/layers/rope.py
-```
+
+`torch.cartesian_prod` is not supported by the ONNX opset. `torch.meshgrid` + `torch.stack` produces the same (y, x) coordinate pairs and is fully ONNX-compatible.

--- a/depth_estimation/depth_anything_v3/export/README.md
+++ b/depth_estimation/depth_anything_v3/export/README.md
@@ -64,7 +64,7 @@ File: `model/dinov2/layers/rope.py` class `PositionGetter.__call__`
 
 ### Patch 2: RoPE frequency components (rope.py)
 
-`int(positions.max())` is a data-dependent conversion that becomes a constant. Use a fixed upper bound (1024, supporting up to 14336px images) instead. Also remove dict caching from `_compute_frequency_components`, and replace `torch.cat((angles, angles), dim=-1)` with `angles.repeat(1, 2)` (ailia SDK does not support Concat with the same tensor as both inputs).
+`int(positions.max())` is a data-dependent conversion that becomes a constant. Use `positions.shape[1]` (= H_patches*W_patches, always >= max(H_patches, W_patches)) as a dynamic upper bound instead. Also remove dict caching from `_compute_frequency_components`, and replace `torch.cat((angles, angles), dim=-1)` with `angles.repeat(1, 2)` (ailia SDK does not support Concat with the same tensor as both inputs).
 
 File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
 
@@ -100,7 +100,7 @@ File: `model/dinov2/layers/rope.py` class `RotaryPositionEmbedding2D`
         max_position = int(positions.max()) + 1
 
 # After (forward)
-        max_position = 1024
+        max_position = positions.shape[1]
 ```
 
 ---

--- a/depth_estimation/depth_anything_v3/export/export_onnx.py
+++ b/depth_estimation/depth_anything_v3/export/export_onnx.py
@@ -132,6 +132,10 @@ def main():
         opset_version=args.opset,
         input_names=['image'],
         output_names=['depth'],
+        dynamic_axes={
+            'image': {0: 'batch', 2: 'height', 3: 'width'},
+            'depth': {0: 'batch', 2: 'height', 3: 'width'},
+        },
         dynamo=False,
     )
 


### PR DESCRIPTION
DepthAnything v3がStatic Shapeだったため、Dynamic Shapeに更新しました。

古いモデル（移動）：https://storage.googleapis.com/ailia-models/depth_anything_v3/legacy/depth_anything_v3_da3_vitb.onnx
新しいモデル：https://storage.googleapis.com/ailia-models/depth_anything_v3/depth_anything_v3_da3_vitb.onnx
#1845 