### PR TITLE
resolve profile penalty during GPU inference (sensevoice)

### DIFF
--- a/audio_processing/sensevoice/funasr_ailia/utils/utils.py
+++ b/audio_processing/sensevoice/funasr_ailia/utils/utils.py
@@ -77,7 +77,8 @@ class AiliaInferSession:
         import ailia
         self.session = ailia.Net(weight=model_file, env_id=env_id, memory_mode=11)
         self.profile = profile
-        self.session.set_profile_mode(True)
+        if self.profile:
+            self.session.set_profile_mode(ailia.PROFILE_AVERAGE)
 
     def __call__(self, input_content: List[Union[np.ndarray, np.ndarray]], run_options = None) -> np.ndarray:
         return self.session.run(input_content)


### PR DESCRIPTION
SenseVoice の CUDA 推論が CPU よりも遅い問題に対処する RP です。

SenseVoice の推論スクリプトに `--profile` オプションを指定しない場合も ailia のインスタンスを作成する際に `set_profile_mode()` を呼んで同期実行モードで動いている問題がありました。

i7-11700 + NVIDIA RTX PRO 4000 Blackwell の環境で `--benchmark -i rd1457.mp3 -e 2` ( [rd1457.mp3](https://aozoraroudoku.jp/voice/rdp/rd1457.html) ) 引数で推論した場合の消費時間が次のように変化し、評価環境では CPU よりも CUDA(FP32) の方が高速になります。

環境 | s2t processing time
-- | --:
CUDA(fp32) + OLD | 18473 ms
CUDA(fp32) + this PR | 9625 ms
参考 (CPU / `-e 0`)  | 13596 ms
