### PR TITLE
PaddleOCRのunclipがnumpy2で動作しない問題を修正

### DIFF
--- a/text_recognition/paddleocr/paddleocr.py
+++ b/text_recognition/paddleocr/paddleocr.py
@@ -506,9 +506,9 @@ class DBPostProcess(object):
         # calculate circle coordinates
         pitch = 10
         x_upper = np.cos(np.arange(1, 0, (-1 / pitch)) * np.pi) * distance
-        y_upper = -np.sqrt(distance ** 2 - x_upper ** 2)
+        y_upper = -np.sqrt(np.maximum(distance ** 2 - x_upper ** 2, 0.0))
         x_lower = np.cos(np.arange(0, 1, (1 / pitch)) * np.pi) * distance
-        y_lower = np.sqrt(distance ** 2 - x_lower ** 2)
+        y_lower = np.sqrt(np.maximum(distance ** 2 - x_lower ** 2, 0.0))
         x = np.concatenate([x_upper, x_lower])
         y = np.concatenate([y_upper, y_lower])
         circle = np.concatenate([x[:, np.newaxis], y[:, np.newaxis]], axis=1)


### PR DESCRIPTION
DBPostProcess.unclip() で、distance ** 2 - x_upper ** 2 が NumPy 2 だと float32 精度の丸めでわずかに負になり、sqrt() が NaN を出すことでした。NumPy 1だとdistance ** 2がfloat64に昇格するので問題は発生しません。

その NaN が int64 に cast されて巨大/負座標の box になり、OCR 結果が崩れていました。 修正は sqrt の中身だけ np.maximum(..., 0.0) で丸め誤差を吸収する最小変更です。NumPy 1 の dtype 挙動は変えないようにしたので、従来出力は維持されます。