### PR TITLE
Switch whether to apply the workaround depending on the ailia version

### DIFF
--- a/text_recognition/paddleocr/paddleocr.py
+++ b/text_recognition/paddleocr/paddleocr.py
@@ -67,7 +67,16 @@ DICT_PATH_REC_KOR_MBL = './dict/kor_eng_num_sym_org.txt'
 IMAGE_OR_VIDEO_PATH = 'input.jpg'
 SAVE_IMAGE_OR_VIDEO_PATH = 'output.png'
 
-REOPEN_REQUIRE_IF_SHAPE_CHANED = True # Require for ailia SDK <= 1.2.16
+version = ailia.get_version().split(".")
+AILIA_VERSION_MAJOR = int(version[0])
+AILIA_VERSION_MINOR = int(version[1])
+AILIA_VERSION_REVISION = int(version[2])
+
+# Require for ailia SDK <= 1.2.16
+REOPEN_REQUIRE_IF_SHAPE_CHANED = (
+    (AILIA_VERSION_MAJOR, AILIA_VERSION_MINOR, AILIA_VERSION_REVISION)
+    <= (1, 2, 16)
+)
 
 # ======================
 # Arguemnt Parser Config


### PR DESCRIPTION
ailia SDK 1.2.16までは使用できなかったDynamic Shapeを1.2.17以降で使用することで速度を改善するPRです。

計測環境
- ailia SDK 1.6
- RTX3080

計測コマンド
- python paddleocr.py -b -c server

変更前
- CPU : 4521ms
- GPU : 2610ms

変更後
- CPU : 2311ms
- GPU : 351ms