### PR TITLE
Add --language option to qwen3-tts

### DIFF
--- a/audio_processing/qwen3-tts/README.md
+++ b/audio_processing/qwen3-tts/README.md
@@ -34,11 +34,22 @@ You can directly pass the text you want to synthesize using the `--input` argume
 python qwen3-tts.py --input "Hello, this is a test of voice cloning." --ref_audio clone_2.wav --ref_text clone_2.txt --savepath output.wav
 ```
 
+### Language
+
+By default the language is auto-detected (`--language Auto`). If the synthesized speech is pronounced in the wrong language (for example, Japanese text being read with a Chinese accent), specify the target language explicitly with the `--language` option.
+
+```bash
+python qwen3-tts.py --input "こんにちは、今日はいい天気ですね。" --language japanese
+```
+
+Supported languages: `Auto` (default), `chinese`, `english`, `japanese`, `korean`, `german`, `french`, `russian`, `portuguese`, `spanish`, `italian`.
+
 ### Options
 
 - `-i`, `--input` Direct input text string to synthesize. (e.g. `Hello, this is a test of voice cloning.`)
 - `--ref_audio` Reference audio file path for Voice Clone mode. (e.g. `clone_2.wav`)
 - `--ref_text` Reference text file path containing the transcript of the reference audio. (e.g. `clone_2.txt`)
+- `--language` Target language for synthesis. `Auto` for auto detection, or one of `chinese`, `english`, `japanese`, `korean`, `german`, `french`, `russian`, `portuguese`, `spanish`, `italian`. (default: `Auto`)
 - `-s`, `--savepath` Save path for the output synthesized audio. (default: `output.wav`)
 
 ## Model Format

--- a/audio_processing/qwen3-tts/README.md
+++ b/audio_processing/qwen3-tts/README.md
@@ -23,6 +23,9 @@ pip install -r requirements.txt
 
 This model supports **Voice Clone (Zero-shot Voice Conversion)** by default. You need to provide a text to synthesize, a reference audio file of the target speaker, and its corresponding text transcript.
 
+The bundled sample reference audio (`clone_2.wav`) and transcript (`clone_2.txt`) are based on the official Qwen3-TTS Voice Clone example. The original reference audio is published as `clone.wav` at:
+`https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-TTS-Repo/clone.wav`
+
 For the sample wav,
 ```bash
 $ python3 qwen3-tts.py

--- a/audio_processing/qwen3-tts/README.md
+++ b/audio_processing/qwen3-tts/README.md
@@ -50,7 +50,15 @@ Supported languages: `Auto` (default), `chinese`, `english`, `japanese`, `korean
 - `--ref_audio` Reference audio file path for Voice Clone mode. (e.g. `clone_2.wav`)
 - `--ref_text` Reference text file path containing the transcript of the reference audio. (e.g. `clone_2.txt`)
 - `--language` Target language for synthesis. `Auto` for auto detection, or one of `chinese`, `english`, `japanese`, `korean`, `german`, `french`, `russian`, `portuguese`, `spanish`, `italian`. (default: `Auto`)
+- `--temperature` Sampling temperature for the talker. `0` for greedy decoding. (default: `0.9`, matches the official implementation)
+- `--top_k` Top-k sampling for the talker. (default: `50`, matches the official implementation)
+- `--repetition_penalty` Repetition penalty for the talker. (default: `1.05`)
+- `--subtalker_temperature` Sampling temperature for the subtalker (code predictor). `0` for greedy decoding. (default: `0.9`, matches the official implementation)
+- `--subtalker_top_k` Top-k sampling for the subtalker (code predictor). (default: `50`, matches the official implementation)
+- `--seed` Random seed for reproducible sampling. (default: `None`)
 - `-s`, `--savepath` Save path for the output synthesized audio. (default: `output.wav`)
+
+> **Note:** Sampling (`temperature=0.9`, `top_k=50`) is used by default to match the official implementation. Set `--temperature 0` for deterministic greedy decoding. Use `--seed` to make sampled output reproducible.
 
 ## Model Format
 

--- a/audio_processing/qwen3-tts/README.md
+++ b/audio_processing/qwen3-tts/README.md
@@ -58,7 +58,7 @@ Supported languages: `Auto` (default), `chinese`, `english`, `japanese`, `korean
 - `--seed` Random seed for reproducible sampling. (default: `None`)
 - `-s`, `--savepath` Save path for the output synthesized audio. (default: `output.wav`)
 
-> **Note:** Sampling (`temperature=0.9`, `top_k=50`) is used by default to match the official implementation. Set `--temperature 0` for deterministic greedy decoding. Use `--seed` to make sampled output reproducible.
+> **Note:** Sampling (`temperature=0.9`, `top_k=50`, `subtalker_temperature=0.9`, `subtalker_top_k=50`) is used by default to match the official implementation. Set both `--temperature 0` and `--subtalker_temperature 0` for deterministic greedy decoding. Use `--seed` to make sampled output reproducible.
 
 ## Model Format
 

--- a/audio_processing/qwen3-tts/qwen3-tts.py
+++ b/audio_processing/qwen3-tts/qwen3-tts.py
@@ -61,10 +61,6 @@ parser.add_argument(
 
 
 parser.add_argument(
-    '--inputType', default="wav",
-    help='[numpy, wav]'
-)
-parser.add_argument(
     '-m', '--model',
     default='base',
     help='[base]'
@@ -79,6 +75,30 @@ parser.add_argument(
     help='Target language. "Auto" for auto detection, or one of: '
          'chinese, english, japanese, korean, german, french, russian, '
          'portuguese, spanish, italian'
+)
+parser.add_argument(
+    '--temperature', type=float, default=0.9,
+    help='Sampling temperature for the talker. 0 for greedy decoding. (default: 0.9, matches official)'
+)
+parser.add_argument(
+    '--top_k', type=int, default=50,
+    help='Top-k sampling for the talker. (default: 50, matches official)'
+)
+parser.add_argument(
+    '--repetition_penalty', type=float, default=1.05,
+    help='Repetition penalty for the talker. (default: 1.05)'
+)
+parser.add_argument(
+    '--subtalker_temperature', type=float, default=0.9,
+    help='Sampling temperature for the subtalker (code predictor). 0 for greedy. (default: 0.9, matches official)'
+)
+parser.add_argument(
+    '--subtalker_top_k', type=int, default=50,
+    help='Top-k sampling for the subtalker (code predictor). (default: 50, matches official)'
+)
+parser.add_argument(
+    '--seed', type=int, default=None,
+    help='Random seed for reproducible sampling. (default: None)'
 )
 parser.add_argument(
     '--disable_ailia_tokenizer', action='store_true', help='disable ailia tokenizer.'
@@ -200,25 +220,6 @@ def mel_spectrogram(y, n_fft, num_mels, sr, hop_size, win_size, fmin, fmax, cent
     spec = spec.T # (Time, 128)
     return np.expand_dims(spec, 0).astype(np.float32) # (1, Time, 128)
 
-def load_wav(full_path):
-    # scipy ではなく librosa を使うのが確実です（PyTorch版と一致させるため）
-    data, sr = librosa.load(full_path, sr=24000, mono=True)
-    return data, sr
-
-def get_mel(PATH_TO_MELL):
-    return  np.load(PATH_TO_MELL)
-
-def check_input_type():
-    if args.input:
-   
-        if args.input.split(".")[0] in ["npy", "wav"]:
-            if args.input.split(".")[0] == "npy":
-                return "numpy"    
-            else:
-                return"wav"   
-    else:
-        return args.inputType
-    
 def load_qwen_config(config_path="config.json"):
     with open(config_path, 'r') as f:
         raw = json.load(f)
@@ -394,7 +395,8 @@ class Qwen3TTS:
         new_kv_caches = [outputs[1 + i] for i in range(NSL * 2)]
         return last_hidden, new_kv_caches
     
-    def _predict_subgroups(self, group0_token: int, past_hidden: np.ndarray) -> list:
+    def _predict_subgroups(self, group0_token: int, past_hidden: np.ndarray,
+                           temperature: float = 0.9, top_k: int = 50) -> list:
         NSL  = self.NUM_SUB_LAYERS
         NKV  = 8
         HDIM = 128
@@ -407,7 +409,7 @@ class Qwen3TTS:
         hidden, sub_kv = self._run_subtalker_decoder(
             prefill_emb, self._sub_attn_prefill, self._sub_pos_prefill, sub_kv
         )
-        group_tokens = [_sample_token(self.subtalker_lm_heads[0] @ hidden[0, -1, :], 0.0)]
+        group_tokens = [_sample_token(self.subtalker_lm_heads[0] @ hidden[0, -1, :], temperature, top_k)]
 
         # ── Decode (seq=1 × 14) ──
         for k in range(1, 15):
@@ -415,7 +417,7 @@ class Qwen3TTS:
             hidden, sub_kv = self._run_subtalker_decoder(
                 emb, self._sub_attn_decode[k-1], self._sub_pos_decode[k-1], sub_kv
             )
-            group_tokens.append(_sample_token(self.subtalker_lm_heads[k] @ hidden[0, -1, :], 0.0))
+            group_tokens.append(_sample_token(self.subtalker_lm_heads[k] @ hidden[0, -1, :], temperature, top_k))
 
         return group_tokens
 
@@ -493,7 +495,9 @@ class Qwen3TTS:
     # ------------------------------------------------------------------
     # predict
     # ------------------------------------------------------------------
-    def predict(self, text, ref_audio=None, ref_text=None, language="Auto"):
+    def predict(self, text, ref_audio=None, ref_text=None, language="Auto",
+                temperature=0.9, top_k=50, repetition_penalty=1.05,
+                subtalker_temperature=0.9, subtalker_top_k=50):
         cfg = self.cfg   # 短縮エイリアス
 
         # ---- 言語ID 解決 ----
@@ -511,23 +515,8 @@ class Qwen3TTS:
             language_id = cfg["codec_language_id"][language.lower()]
 
         # ---- 参照音声 ----
-        if ref_audio is not None:
-            inputTypes = check_input_type()
-            if inputTypes != "numpy":
-                wav, sr = load_wav(ref_audio)
-                wav = np.expand_dims(wav, axis=0)
-                mel_outputs = mel_spectrogram(wav, n_fft, num_mels, sampling_rate,
-                                               hop_size, win_size, fmin, fmax)
-            else:
-                mel_outputs = get_mel(ref_audio)
-
-            speaker_vec = self.speaker_encoder.run([mel_outputs])[0]
-
-            wav, sr   = librosa.load(ref_audio, sr=24000, mono=True)
-            wav_input = wav[np.newaxis, np.newaxis, :].astype(np.float32)
-            self.tokenizer_encoder.set_input_blob_shape(wav_input.shape, 0)
-            ref_code = self.tokenizer_encoder.run([wav_input])[0]
-            ref_code = np.squeeze(ref_code, axis=0)  # [16, T]
+        #   speaker embedding / ref_code は create_voice_clone_prompt() で
+        #   一括して計算する (ここで二重に encode しない)。
 
         if ref_text is not None:
             ref_text_formatted = f"<|im_start|>assistant\n{ref_text}<|im_end|>\n"
@@ -649,9 +638,7 @@ class Qwen3TTS:
 
         EOS_TOKEN_ID  = cfg["codec_eos_id"]   # 2150
         MAX_NEW_TOKENS = 2048
-        temperature    = 0.0
-        top_k          = 1
-        rep_penalty    = 1.05
+        rep_penalty    = repetition_penalty
 
         curr_token_id = _sample_token(logits[0, -1, :], temperature, top_k)
         past_hidden = last_hidden[:, -1:, :].astype(np.float32)
@@ -669,7 +656,10 @@ class Qwen3TTS:
                 break
  
             # ── subtalker でグループ 1〜15 を予測 ──────────────────
-            sub_tokens     = self._predict_subgroups(curr_token_id, past_hidden)
+            sub_tokens     = self._predict_subgroups(
+                curr_token_id, past_hidden,
+                temperature=subtalker_temperature, top_k=subtalker_top_k,
+            )
             all_group_tokens = [curr_token_id] + sub_tokens   # len=16
  
             generated_ids.append(curr_token_id)
@@ -729,11 +719,33 @@ class Qwen3TTS:
         for t, group_toks in enumerate(all_codes_list):
             for g in range(16):
                 all_codes[0, g, t] = group_toks[g]
- 
-        self.tokenizer_decoder.set_input_blob_shape(all_codes.shape, 0)
-        final_waveform = self.tokenizer_decoder.run([all_codes])[0]
- 
-        return final_waveform
+
+        # ── 公式準拠: 参照codecを前に連結してdecodeし、先頭を比率カット ──
+        #   (model.py generate_voice_clone L612-631)
+        #   decoder は causal なので、参照フレームを前置きして文脈を与え、
+        #   生成した波形の先頭(参照分)を比率で切り落とす。
+        ref_code = voice_clone_prompt.ref_code   # [>=16, T_ref] or None
+        if ref_code is not None:
+            # 生成コード(all_codes)は16コードブック。ICLプロンプトと同様に
+            # 先頭16行を使う (encoder出力は16より多い場合がある)。
+            ref_code16 = ref_code[:16, :]
+            ref_T = ref_code16.shape[1]
+            codes_for_decode = np.concatenate(
+                [ref_code16[np.newaxis, :, :].astype(np.int64), all_codes], axis=2
+            )  # [1, 16, T_ref + T]
+        else:
+            ref_T = 0
+            codes_for_decode = all_codes
+
+        self.tokenizer_decoder.set_input_blob_shape(codes_for_decode.shape, 0)
+        wav = np.squeeze(self.tokenizer_decoder.run([codes_for_decode])[0])  # [L]
+
+        if ref_T > 0:
+            total_T = codes_for_decode.shape[2]
+            cut = int(ref_T / max(total_T, 1) * wav.shape[0])
+            wav = wav[cut:]
+
+        return wav
     
 def main():
     for onnx, prototxt in onnx_list:
@@ -746,16 +758,27 @@ def main():
     reduce_interstage=False, 
     reuse_interstage=True  
     )
+    # 0. 乱数シード (サンプリングの再現性用)
+    if args.seed is not None:
+        np.random.seed(args.seed)
+
     # 1. セットアップ
     tts_engine = Qwen3TTS(memory_mode)
-    
+
     # 2. 検証用データの指定
     with open(args.ref_text, "r", encoding="utf-8") as f:
                 wav_text = f.read()
 
-    # 3. 推論実行 (Greedyモード)
+    # 3. 推論実行
     print("Generating speech...")
-    waveform = tts_engine.predict(args.input, ref_audio=args.ref_audio, ref_text=wav_text, language=args.language)
+    waveform = tts_engine.predict(
+        args.input, ref_audio=args.ref_audio, ref_text=wav_text,
+        language=args.language,
+        temperature=args.temperature, top_k=args.top_k,
+        repetition_penalty=args.repetition_penalty,
+        subtalker_temperature=args.subtalker_temperature,
+        subtalker_top_k=args.subtalker_top_k,
+    )
     
     # 4. 保存
     sf.write(args.savepath, waveform.squeeze(), 24000)

--- a/audio_processing/qwen3-tts/qwen3-tts.py
+++ b/audio_processing/qwen3-tts/qwen3-tts.py
@@ -43,7 +43,8 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/qwen3-tts/"
 parser = get_base_parser(
     'QWEN3 TTS', 
     TEXT_STR, 
-    OUTPUT_WAV_PATH   
+    OUTPUT_WAV_PATH,
+    large_model = True
 )
 
 # 参照音声ファイルのパス
@@ -72,6 +73,12 @@ parser.add_argument(
     '-p', '--parameter_num',
     default='0.6B',
     help='[0.6B, 1.8B]'
+)
+parser.add_argument(
+    '--language', type=str, default='Auto',
+    help='Target language. "Auto" for auto detection, or one of: '
+         'chinese, english, japanese, korean, german, french, russian, '
+         'portuguese, spanish, italian'
 )
 parser.add_argument(
     '--disable_ailia_tokenizer', action='store_true', help='disable ailia tokenizer.'
@@ -229,6 +236,7 @@ def load_qwen_config(config_path="config.json"):
         "codec_eos_id":       tc["codec_eos_token_id"],   # 2150 
         "codec_pad_id":       tc["codec_pad_id"],         # 2148
         "codec_nothink_id":   tc["codec_nothink_id"],     # 2155
+        "codec_think_id":     tc["codec_think_id"],       # 2154
         "codec_think_bos_id": tc["codec_think_bos_id"],   # 2156
         "codec_think_eos_id": tc["codec_think_eos_id"],   # 2157
         "codec_language_id":  tc.get("codec_language_id", {}),
@@ -485,8 +493,22 @@ class Qwen3TTS:
     # ------------------------------------------------------------------
     # predict
     # ------------------------------------------------------------------
-    def predict(self, text, ref_audio=None, ref_text=None):
+    def predict(self, text, ref_audio=None, ref_text=None, language="Auto"):
         cfg = self.cfg   # 短縮エイリアス
+
+        # ---- 言語ID 解決 ----
+        #   "Auto" → language_id=None (自動判定: nothink パス)
+        #   明示指定 → codec_language_id から取得 (think パス)
+        if language is None or language.lower() == "auto":
+            language_id = None
+        else:
+            if language.lower() not in cfg["codec_language_id"]:
+                logger.error(
+                    f"Unsupported language: {language}. "
+                    f"Supported: Auto, {', '.join(cfg['codec_language_id'].keys())}"
+                )
+                sys.exit()
+            language_id = cfg["codec_language_id"][language.lower()]
 
         # ---- 参照音声 ----
         if ref_audio is not None:
@@ -541,17 +563,25 @@ class Qwen3TTS:
         tts_pad_embed = projected_specials[:, 2:3, :]
 
         # ---- codec tag 埋め込み ----
-        tag_ids_0 = [cfg["codec_nothink_id"],   # 2155
-                     cfg["codec_think_bos_id"],  # 2156
-                     cfg["codec_think_eos_id"]]  # 2157 
+        #   Auto (language_id=None): [nothink, think_bos, think_eos]            (3 tokens)
+        #   明示指定:                [think,   think_bos, language_id, think_eos] (4 tokens)
+        if language_id is None:
+            tag_ids_0 = [cfg["codec_nothink_id"],    # 2155
+                         cfg["codec_think_bos_id"],  # 2156
+                         cfg["codec_think_eos_id"]]  # 2157
+        else:
+            tag_ids_0 = [cfg["codec_think_id"],      # 2154
+                         cfg["codec_think_bos_id"],  # 2156
+                         language_id,                # e.g. japanese=2058
+                         cfg["codec_think_eos_id"]]  # 2157
         tag_ids_1 = [cfg["codec_pad_id"],        # 2148
-                     cfg["codec_bos_id"]]         # 2149 
-        tag_part0   = self.codec_emb_weight[0][tag_ids_0]          # [3, 1024]
+                     cfg["codec_bos_id"]]         # 2149
+        tag_part0   = self.codec_emb_weight[0][tag_ids_0]          # [3 or 4, 1024]
         tag_part_spk = spk_emb[np.newaxis, :]                      # [1, 1024]
         tag_part1   = self.codec_emb_weight[0][tag_ids_1]          # [2, 1024]
         codec_tag_emb = np.expand_dims(
             np.concatenate([tag_part0, tag_part_spk, tag_part1], axis=0), axis=0
-        )  # [1, 6, 1024]
+        )  # [1, 6 or 7, 1024]
 
         # ---- role 投影 ----
         role_ids  = [cfg["im_start_id"], cfg["assistant_id"], 198]  # 198=\n
@@ -561,7 +591,9 @@ class Qwen3TTS:
         )[0]  # [1, 3, 1024]
 
         # ---- tag 投影 ----
-        tag_base_ids  = [cfg["tts_pad_id"]] * 4 + [cfg["tts_bos_id"]] 
+        #   tts_pad * (codec_tag_len - 2) + tts_bos  → codec_tag_emb[:, :-1] と同じ長さ
+        num_tts_pad   = codec_tag_emb.shape[1] - 2
+        tag_base_ids  = [cfg["tts_pad_id"]] * num_tts_pad + [cfg["tts_bos_id"]]
         tag_base_proj = self.talker_io.run(
             [self.text_emb_weight[tag_base_ids][np.newaxis, :].astype(np.float32),
              np.zeros((1, 1, 1024), dtype=np.float32)]
@@ -723,7 +755,7 @@ def main():
 
     # 3. 推論実行 (Greedyモード)
     print("Generating speech...")
-    waveform = tts_engine.predict(args.input, ref_audio=args.ref_audio, ref_text=wav_text)
+    waveform = tts_engine.predict(args.input, ref_audio=args.ref_audio, ref_text=wav_text, language=args.language)
     
     # 4. 保存
     sf.write(args.savepath, waveform.squeeze(), 24000)


### PR DESCRIPTION
- 言語オプションを追加

Add explicit language selection to qwen3-tts. The previous code only implemented the "Auto" (language_id=None) path, so Japanese text could be pronounced with a Chinese accent. When a language is specified, the codec prefill switches to the think path with the language id inserted, matching the official inference code.

```
python3 qwen3-tts.py -i "こんにちは、今 日はいい天気ですね。" --language japanese
```

- 不要な2回目のエンコードを削除
- サンプリングをgreedyからsamplerに変更