### PR TITLE
Add separated image/text encoder support to siglip2

### DIFF
--- a/image_classification/siglip2/README.md
+++ b/image_classification/siglip2/README.md
@@ -10,10 +10,10 @@
 
 - Zero-Shot Prediction
 ```bash
-1: 2 cats - 65.41%
-2: 3 dogs - 32.62%
-3: a remote - 1.05%
-4: a plane - 0.92%
+1: 2 cats - 92.34%
+2: a remote - 7.65%
+3: 3 dogs - 0.00%
+4: a plane - 0.00%
 ```
 
 ## Requirements

--- a/image_classification/siglip2/README.md
+++ b/image_classification/siglip2/README.md
@@ -49,7 +49,7 @@ By adding the `--model_type` option, you can specify model type which is selecte
 $ python3 siglip2.py --model_type base-patch16-224
 ```
 
-By adding the `--separate` option, you can use models separated into an image encoder and a text encoder.
+By adding the `--separate` option, you can use models separated into an image encoder and a text encoder. (base-patch16-224 only)
 The text features are computed only once, so this is efficient when processing multiple images with the same labels.
 ```bash
 $ python3 siglip2.py --separate

--- a/image_classification/siglip2/README.md
+++ b/image_classification/siglip2/README.md
@@ -49,6 +49,12 @@ By adding the `--model_type` option, you can specify model type which is selecte
 $ python3 siglip2.py --model_type base-patch16-224
 ```
 
+By adding the `--separate` option, you can use models separated into an image encoder and a text encoder.
+The text features are computed only once, so this is efficient when processing multiple images with the same labels.
+```bash
+$ python3 siglip2.py --separate
+```
+
 ## Reference
 
 - [Hugging Face - SigLIP 2 Base](https://huggingface.co/google/siglip2-base-patch16-224)
@@ -65,3 +71,5 @@ ONNX opset=17
 ## Netron
 
 [siglip2-base-patch16-224.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/siglip2/siglip2-base-patch16-224.onnx.prototxt)  
+[siglip2-base-patch16-224-encode_image.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/siglip2/siglip2-base-patch16-224-encode_image.onnx.prototxt)  
+[siglip2-base-patch16-224-encode_text.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/siglip2/siglip2-base-patch16-224-encode_text.onnx.prototxt)  

--- a/image_classification/siglip2/export/README.md
+++ b/image_classification/siglip2/export/README.md
@@ -1,0 +1,64 @@
+# SigLIP2 ONNX Separation
+
+Split the combined SigLIP2 ONNX model (`input_ids` + `pixel_values` -> `logits_per_image`)
+into an image encoder and a text encoder.
+
+## Usage
+
+Place the combined onnx model (and its `_weights.pb` for large/giant) in the model
+directory (`..`), then run:
+
+```bash
+pip install onnx numpy
+python separate_onnx.py -m base-patch16-224   # or large-patch16-256, giant-patch16-256
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-m`, `--model_type` | `base-patch16-224` | Model type: `base-patch16-224`, `large-patch16-256`, `giant-patch16-256` |
+| `--input_dir` | `..` | Directory containing the combined onnx model |
+| `--output_dir` | `..` | Directory to save the separated onnx models |
+
+## Outputs
+
+- `siglip2-<model>-encode_image.onnx`
+  - Input: `pixel_values` `[n, 3, H, W]`
+  - Output: `image_embeds` (L2 normalized)
+- `siglip2-<model>-encode_text.onnx`
+  - Input: `input_ids` `[b, l]`
+  - Outputs: `text_embeds` (L2 normalized), `logit_scale` (exp applied), `logit_bias`
+
+If the source model uses external weights (`_weights.pb`), the separated models are
+saved with external weights as well (`-encode_image_weights.pb` / `-encode_text_weights.pb`).
+
+`logits_per_image` can be reconstructed as:
+
+```python
+logits_per_image = image_embeds @ text_embeds.T * logit_scale + logit_bias
+```
+
+## Prototxt
+
+Generate prototxt files with
+[onnx2prototxt.py](https://github.com/ailia-ai/export-to-onnx/blob/master/onnx2prototxt.py):
+
+```bash
+python onnx2prototxt.py siglip2-<model>-encode_image.onnx
+python onnx2prototxt.py siglip2-<model>-encode_text.onnx
+```
+
+## Note
+
+`siglip2.py --separate` currently supports base-patch16-224 only.
+
+## Verification
+
+The separated models were verified against the combined model with onnxruntime
+(max abs diff of `logits_per_image`: ~4e-6 on base-patch16-224).
+
+```bash
+python siglip2.py --separate --onnx
+python siglip2.py --separate
+```

--- a/image_classification/siglip2/export/separate_onnx.py
+++ b/image_classification/siglip2/export/separate_onnx.py
@@ -1,0 +1,278 @@
+import argparse
+import os
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper
+from onnx.external_data_helper import load_external_data_for_tensor, uses_external_data
+
+"""
+Split the combined SigLIP2 ONNX model (input_ids + pixel_values -> logits_per_image)
+into a text encoder and an image encoder.
+
+- encode_image: pixel_values -> image_embeds (L2 normalized)
+- encode_text:  input_ids -> text_embeds (L2 normalized), logit_scale (exp applied), logit_bias
+
+logits_per_image can be reconstructed as:
+    image_embeds @ text_embeds.T * logit_scale + logit_bias
+"""
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    "-m",
+    "--model_type",
+    default="base-patch16-224",
+    choices=("base-patch16-224", "large-patch16-256", "giant-patch16-256"),
+    help="model type",
+)
+parser.add_argument(
+    "--input_dir",
+    default="..",
+    help="directory containing the combined onnx model",
+)
+parser.add_argument(
+    "--output_dir",
+    default="..",
+    help="directory to save the separated onnx models",
+)
+args = parser.parse_args()
+
+DIC_STEM = {
+    "base-patch16-224": "siglip2-base-patch16-224",
+    "large-patch16-256": "siglip2-large-patch16-256",
+    "giant-patch16-256": "siglip2-giant-opt-patch16-256",
+}
+
+
+def reaches_input(graph, producer, tensor_name, input_name):
+    """Check if tensor_name depends on the graph input input_name."""
+    stack = [tensor_name]
+    visited = set()
+    while stack:
+        name = stack.pop()
+        if name in visited:
+            continue
+        visited.add(name)
+        if name == input_name:
+            return True
+        node = producer.get(name)
+        if node is not None:
+            stack.extend(node.input)
+    return False
+
+
+def find_split_tensors(graph):
+    """
+    Walk backward from logits_per_image to locate the normalized embedding
+    tensors and the logit_scale/logit_bias parameters.
+
+    Expected tail of the graph:
+        MatMul(text_embeds, Cast(Transpose(image_embeds)))
+        -> Mul(., Exp(logit_scale)) -> Add(., logit_bias)
+        -> Transpose -> logits_per_image
+    """
+    producer = {o: n for n in graph.node for o in n.output}
+    initializers = {i.name: i for i in graph.initializer}
+
+    node = producer["logits_per_image"]
+    if node.op_type == "Transpose":
+        node = producer[node.input[0]]
+
+    assert node.op_type == "Add", f"unexpected op: {node.op_type}"
+    add_inputs = list(node.input)
+    mul_out = next(x for x in add_inputs if x in producer and producer[x].op_type == "Mul")
+    logit_bias_name = next(x for x in add_inputs if x != mul_out)
+
+    node = producer[mul_out]  # Mul
+    matmul_out = next(
+        x for x in node.input if x in producer and producer[x].op_type == "MatMul"
+    )
+    exp_out = next(x for x in node.input if x != matmul_out)
+    logit_scale_name = producer[exp_out].input[0]  # Exp input
+
+    matmul = producer[matmul_out]
+
+    embeds = []
+    for x in matmul.input:
+        name = x
+        # skip Cast/Transpose inserted before MatMul
+        while name in producer and producer[name].op_type in ("Cast", "Transpose"):
+            name = producer[name].input[0]
+        embeds.append(name)
+
+    text_embeds = next(
+        x for x in embeds if reaches_input(graph, producer, x, "input_ids")
+    )
+    image_embeds = next(
+        x for x in embeds if reaches_input(graph, producer, x, "pixel_values")
+    )
+
+    return image_embeds, text_embeds, logit_scale_name, logit_bias_name, initializers
+
+
+def get_scalar(graph, initializers, base_dir, name):
+    """Get a scalar parameter value from an initializer or a Constant node."""
+    if name in initializers:
+        tensor = initializers[name]
+        if uses_external_data(tensor):
+            load_external_data_for_tensor(tensor, base_dir)
+        return onnx.numpy_helper.to_array(tensor).astype(np.float32).reshape(-1)
+    for node in graph.node:
+        if name in node.output and node.op_type == "Constant":
+            for attr in node.attribute:
+                if attr.name == "value":
+                    return (
+                        onnx.numpy_helper.to_array(attr.t)
+                        .astype(np.float32)
+                        .reshape(-1)
+                    )
+    raise ValueError(f"scalar parameter not found: {name}")
+
+
+def extract_subgraph(model, base_dir, input_names, outputs, extra_initializers=()):
+    """
+    Extract the subgraph required to compute the given output tensors.
+
+    outputs: list of (source tensor name, renamed output name)
+    extra_initializers: list of (numpy array, output name) appended as
+        Identity outputs (used for logit_scale / logit_bias)
+    """
+    graph = model.graph
+    producer = {o: n for n in graph.node for o in n.output}
+    initializers = {i.name: i for i in graph.initializer}
+    graph_inputs = {i.name: i for i in graph.input}
+
+    needed_nodes = set()
+    needed_inits = []
+    visited = set()
+    stack = [name for name, _ in outputs]
+    while stack:
+        name = stack.pop()
+        if name in visited or name in graph_inputs:
+            continue
+        visited.add(name)
+        if name in initializers:
+            needed_inits.append(initializers[name])
+            continue
+        node = producer.get(name)
+        if node is None:
+            continue
+        if id(node) not in needed_nodes:
+            needed_nodes.add(id(node))
+            stack.extend(node.input)
+
+    nodes = [n for n in graph.node if id(n) in needed_nodes]
+
+    # load external data for required initializers only
+    for tensor in needed_inits:
+        if uses_external_data(tensor):
+            load_external_data_for_tensor(tensor, base_dir)
+
+    # rename outputs via Identity
+    output_vi = []
+    for tensor, new_name in outputs:
+        nodes.append(helper.make_node("Identity", [tensor], [new_name]))
+        output_vi.append(helper.make_tensor_value_info(new_name, TensorProto.FLOAT, None))
+
+    # embed scalar parameters as outputs
+    for array, new_name in extra_initializers:
+        init_name = new_name + "_value"
+        needed_inits.append(onnx.numpy_helper.from_array(array, init_name))
+        nodes.append(helper.make_node("Identity", [init_name], [new_name]))
+        output_vi.append(helper.make_tensor_value_info(new_name, TensorProto.FLOAT, None))
+
+    new_graph = helper.make_graph(
+        nodes,
+        graph.name,
+        [graph_inputs[name] for name in input_names],
+        output_vi,
+        initializer=needed_inits,
+    )
+    new_model = helper.make_model(new_graph, opset_imports=model.opset_import)
+    new_model.ir_version = model.ir_version
+
+    return new_model
+
+
+def save_model(model, output_path, use_external_data):
+    if use_external_data:
+        location = os.path.splitext(os.path.basename(output_path))[0] + "_weights.pb"
+        pb_path = os.path.join(os.path.dirname(output_path), location)
+        if os.path.exists(pb_path):
+            os.remove(pb_path)
+        onnx.save_model(
+            model,
+            output_path,
+            save_as_external_data=True,
+            all_tensors_to_one_file=True,
+            location=location,
+            size_threshold=1024,
+        )
+        print(f"saved: {output_path} (+ {location})")
+    else:
+        onnx.save_model(model, output_path)
+        print(f"saved: {output_path}")
+
+
+def main():
+    stem = DIC_STEM[args.model_type]
+    input_path = os.path.join(args.input_dir, stem + ".onnx")
+
+    print(f"loading: {input_path}")
+    model = onnx.load(input_path, load_external_data=False)
+    base_dir = os.path.dirname(os.path.abspath(input_path))
+    graph = model.graph
+
+    (
+        image_embeds,
+        text_embeds,
+        logit_scale_name,
+        logit_bias_name,
+        initializers,
+    ) = find_split_tensors(graph)
+    print(f"image_embeds: {image_embeds}")
+    print(f"text_embeds: {text_embeds}")
+
+    logit_scale = np.exp(get_scalar(graph, initializers, base_dir, logit_scale_name))
+    logit_bias = get_scalar(graph, initializers, base_dir, logit_bias_name)
+    print(f"logit_scale (exp applied): {logit_scale}")
+    print(f"logit_bias: {logit_bias}")
+
+    # follow the combined model: large/giant use external weights (.pb)
+    use_external_data = any(uses_external_data(i) for i in graph.initializer)
+
+    print("extracting image encoder...")
+    image_model = extract_subgraph(
+        model,
+        base_dir,
+        ["pixel_values"],
+        [(image_embeds, "image_embeds")],
+    )
+    save_model(
+        image_model,
+        os.path.join(args.output_dir, stem + "-encode_image.onnx"),
+        use_external_data,
+    )
+
+    # reload to drop external data loaded in memory for the image encoder
+    model = onnx.load(input_path, load_external_data=False)
+
+    print("extracting text encoder...")
+    text_model = extract_subgraph(
+        model,
+        base_dir,
+        ["input_ids"],
+        [(text_embeds, "text_embeds")],
+        extra_initializers=[(logit_scale, "logit_scale"), (logit_bias, "logit_bias")],
+    )
+    save_model(
+        text_model,
+        os.path.join(args.output_dir, stem + "-encode_text.onnx"),
+        use_external_data,
+    )
+
+    print("done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/image_classification/siglip2/siglip2.py
+++ b/image_classification/siglip2/siglip2.py
@@ -33,22 +33,9 @@ PB_LARGE_P16_256_PATH = "siglip2-large-patch16-256_weights.pb"
 PB_GIANT_P16_256_PATH = "siglip2-giant-opt-patch16-256_weights.pb"
 
 WEIGHT_BASE_P16_224_IMAGE_PATH = "siglip2-base-patch16-224-encode_image.onnx"
-WEIGHT_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image.onnx"
-WEIGHT_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image.onnx"
 MODEL_BASE_P16_224_IMAGE_PATH = "siglip2-base-patch16-224-encode_image.onnx.prototxt"
-MODEL_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image.onnx.prototxt"
-MODEL_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image.onnx.prototxt"
-PB_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image_weights.pb"
-PB_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image_weights.pb"
-
 WEIGHT_BASE_P16_224_TEXT_PATH = "siglip2-base-patch16-224-encode_text.onnx"
-WEIGHT_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text.onnx"
-WEIGHT_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text.onnx"
 MODEL_BASE_P16_224_TEXT_PATH = "siglip2-base-patch16-224-encode_text.onnx.prototxt"
-MODEL_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text.onnx.prototxt"
-MODEL_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text.onnx.prototxt"
-PB_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text_weights.pb"
-PB_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text_weights.pb"
 
 REMOTE_PATH = "https://storage.googleapis.com/ailia-models/siglip2/"
 
@@ -78,7 +65,8 @@ parser.add_argument(
 parser.add_argument(
     "--separate",
     action="store_true",
-    help="use models separated into an image encoder and a text encoder.",
+    help="use models separated into an image encoder and a text encoder. "
+    "(base-patch16-224 only)",
 )
 parser.add_argument(
     "--disable_ailia_tokenizer", action="store_true", help="disable ailia tokenizer."
@@ -248,32 +236,8 @@ def main():
     }
     dic_model_separate = {
         "base-patch16-224": (
-            (WEIGHT_BASE_P16_224_IMAGE_PATH, MODEL_BASE_P16_224_IMAGE_PATH, None),
-            (WEIGHT_BASE_P16_224_TEXT_PATH, MODEL_BASE_P16_224_TEXT_PATH, None),
-        ),
-        "large-patch16-256": (
-            (
-                WEIGHT_LARGE_P16_256_IMAGE_PATH,
-                MODEL_LARGE_P16_256_IMAGE_PATH,
-                PB_LARGE_P16_256_IMAGE_PATH,
-            ),
-            (
-                WEIGHT_LARGE_P16_256_TEXT_PATH,
-                MODEL_LARGE_P16_256_TEXT_PATH,
-                PB_LARGE_P16_256_TEXT_PATH,
-            ),
-        ),
-        "giant-patch16-256": (
-            (
-                WEIGHT_GIANT_P16_256_IMAGE_PATH,
-                MODEL_GIANT_P16_256_IMAGE_PATH,
-                PB_GIANT_P16_256_IMAGE_PATH,
-            ),
-            (
-                WEIGHT_GIANT_P16_256_TEXT_PATH,
-                MODEL_GIANT_P16_256_TEXT_PATH,
-                PB_GIANT_P16_256_TEXT_PATH,
-            ),
+            (WEIGHT_BASE_P16_224_IMAGE_PATH, MODEL_BASE_P16_224_IMAGE_PATH),
+            (WEIGHT_BASE_P16_224_TEXT_PATH, MODEL_BASE_P16_224_TEXT_PATH),
         ),
     }
     model_type = args.model_type
@@ -281,19 +245,19 @@ def main():
     env_id = args.env_id
 
     if args.separate:
+        if model_type not in dic_model_separate:
+            logger.error(f"--separate is not supported for {model_type}.")
+            sys.exit(1)
+
         (
-            (WEIGHT_IMAGE_PATH, MODEL_IMAGE_PATH, PB_IMAGE_PATH),
-            (WEIGHT_TEXT_PATH, MODEL_TEXT_PATH, PB_TEXT_PATH),
+            (WEIGHT_IMAGE_PATH, MODEL_IMAGE_PATH),
+            (WEIGHT_TEXT_PATH, MODEL_TEXT_PATH),
         ) = dic_model_separate[model_type]
 
         logger.info("Checking encode_image model...")
         check_and_download_models(WEIGHT_IMAGE_PATH, MODEL_IMAGE_PATH, REMOTE_PATH)
-        if PB_IMAGE_PATH:
-            check_and_download_file(PB_IMAGE_PATH, REMOTE_PATH)
         logger.info("Checking encode_text model...")
         check_and_download_models(WEIGHT_TEXT_PATH, MODEL_TEXT_PATH, REMOTE_PATH)
-        if PB_TEXT_PATH:
-            check_and_download_file(PB_TEXT_PATH, REMOTE_PATH)
 
         # initialize
         if not args.onnx:

--- a/image_classification/siglip2/siglip2.py
+++ b/image_classification/siglip2/siglip2.py
@@ -31,6 +31,25 @@ MODEL_LARGE_P16_256_PATH = "siglip2-large-patch16-256.onnx.prototxt"
 MODEL_GIANT_P16_256_PATH = "siglip2-giant-opt-patch16-256.onnx.prototxt"
 PB_LARGE_P16_256_PATH = "siglip2-large-patch16-256_weights.pb"
 PB_GIANT_P16_256_PATH = "siglip2-giant-opt-patch16-256_weights.pb"
+
+WEIGHT_BASE_P16_224_IMAGE_PATH = "siglip2-base-patch16-224-encode_image.onnx"
+WEIGHT_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image.onnx"
+WEIGHT_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image.onnx"
+MODEL_BASE_P16_224_IMAGE_PATH = "siglip2-base-patch16-224-encode_image.onnx.prototxt"
+MODEL_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image.onnx.prototxt"
+MODEL_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image.onnx.prototxt"
+PB_LARGE_P16_256_IMAGE_PATH = "siglip2-large-patch16-256-encode_image_weights.pb"
+PB_GIANT_P16_256_IMAGE_PATH = "siglip2-giant-opt-patch16-256-encode_image_weights.pb"
+
+WEIGHT_BASE_P16_224_TEXT_PATH = "siglip2-base-patch16-224-encode_text.onnx"
+WEIGHT_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text.onnx"
+WEIGHT_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text.onnx"
+MODEL_BASE_P16_224_TEXT_PATH = "siglip2-base-patch16-224-encode_text.onnx.prototxt"
+MODEL_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text.onnx.prototxt"
+MODEL_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text.onnx.prototxt"
+PB_LARGE_P16_256_TEXT_PATH = "siglip2-large-patch16-256-encode_text_weights.pb"
+PB_GIANT_P16_256_TEXT_PATH = "siglip2-giant-opt-patch16-256-encode_text_weights.pb"
+
 REMOTE_PATH = "https://storage.googleapis.com/ailia-models/siglip2/"
 
 IMAGE_PATH = "demo.jpg"
@@ -55,6 +74,11 @@ parser.add_argument(
     default="base-patch16-224",
     choices=("base-patch16-224", "large-patch16-256", "giant-patch16-256"),
     help="model type",
+)
+parser.add_argument(
+    "--separate",
+    action="store_true",
+    help="use models separated into an image encoder and a text encoder.",
 )
 parser.add_argument(
     "--disable_ailia_tokenizer", action="store_true", help="disable ailia tokenizer."
@@ -102,16 +126,43 @@ def postprocess_result(logits_per_image, top_k: int = 5):
     return top_labels, top_probs
 
 
+def predict_text_feature(models, input_ids):
+    # feedforward
+    net_text = models["net_text"]
+    if not args.onnx:
+        output = net_text.predict([input_ids])
+    else:
+        output = net_text.run(None, {"input_ids": input_ids})
+    text_embeds, logit_scale, logit_bias = output
+
+    return text_embeds, logit_scale, logit_bias
+
+
 def predict(models, img, input_ids):
     pixel_values = preprocess(img, models["model_type"])
 
     # feedforward
-    net = models["net"]
-    if not args.onnx:
-        output = net.predict([input_ids, pixel_values])
+    if args.separate:
+        net_image = models["net_image"]
+        if not args.onnx:
+            output = net_image.predict([pixel_values])
+        else:
+            output = net_image.run(None, {"pixel_values": pixel_values})
+        image_embeds = output[0]
+
+        text_embeds = models["text_embeds"]
+        logits_per_image = (
+            image_embeds @ text_embeds.T * models["logit_scale"] + models["logit_bias"]
+        )
     else:
-        output = net.run(None, {"input_ids": input_ids, "pixel_values": pixel_values})
-    logits_per_image = output[0]
+        net = models["net"]
+        if not args.onnx:
+            output = net.predict([input_ids, pixel_values])
+        else:
+            output = net.run(
+                None, {"input_ids": input_ids, "pixel_values": pixel_values}
+            )
+        logits_per_image = output[0]
 
     return logits_per_image
 
@@ -134,7 +185,11 @@ def recognize_from_image(models):
     if not args.disable_ailia_tokenizer:
         input_ids = input_ids[:,1:] # remove bos token
 
-    net = models["net"]
+    if args.separate:
+        text_embeds, logit_scale, logit_bias = predict_text_feature(models, input_ids)
+        models["text_embeds"] = text_embeds
+        models["logit_scale"] = logit_scale
+        models["logit_bias"] = logit_bias
 
     # input image loop
     for image_path in args.input:
@@ -191,22 +246,78 @@ def main():
             PB_GIANT_P16_256_PATH,
         ),
     }
+    dic_model_separate = {
+        "base-patch16-224": (
+            (WEIGHT_BASE_P16_224_IMAGE_PATH, MODEL_BASE_P16_224_IMAGE_PATH, None),
+            (WEIGHT_BASE_P16_224_TEXT_PATH, MODEL_BASE_P16_224_TEXT_PATH, None),
+        ),
+        "large-patch16-256": (
+            (
+                WEIGHT_LARGE_P16_256_IMAGE_PATH,
+                MODEL_LARGE_P16_256_IMAGE_PATH,
+                PB_LARGE_P16_256_IMAGE_PATH,
+            ),
+            (
+                WEIGHT_LARGE_P16_256_TEXT_PATH,
+                MODEL_LARGE_P16_256_TEXT_PATH,
+                PB_LARGE_P16_256_TEXT_PATH,
+            ),
+        ),
+        "giant-patch16-256": (
+            (
+                WEIGHT_GIANT_P16_256_IMAGE_PATH,
+                MODEL_GIANT_P16_256_IMAGE_PATH,
+                PB_GIANT_P16_256_IMAGE_PATH,
+            ),
+            (
+                WEIGHT_GIANT_P16_256_TEXT_PATH,
+                MODEL_GIANT_P16_256_TEXT_PATH,
+                PB_GIANT_P16_256_TEXT_PATH,
+            ),
+        ),
+    }
     model_type = args.model_type
-    WEIGTH_PATH, MODEL_PATH, PB_PATH = dic_model[model_type]
-
-    check_and_download_models(WEIGTH_PATH, MODEL_PATH, REMOTE_PATH)
-    if PB_PATH:
-        check_and_download_file(PB_PATH, REMOTE_PATH)
 
     env_id = args.env_id
 
-    # initialize
-    if not args.onnx:
-        net = ailia.Net(MODEL_PATH, WEIGTH_PATH, env_id=env_id)
-    else:
-        import onnxruntime
+    if args.separate:
+        (
+            (WEIGHT_IMAGE_PATH, MODEL_IMAGE_PATH, PB_IMAGE_PATH),
+            (WEIGHT_TEXT_PATH, MODEL_TEXT_PATH, PB_TEXT_PATH),
+        ) = dic_model_separate[model_type]
 
-        net = onnxruntime.InferenceSession(WEIGTH_PATH)
+        logger.info("Checking encode_image model...")
+        check_and_download_models(WEIGHT_IMAGE_PATH, MODEL_IMAGE_PATH, REMOTE_PATH)
+        if PB_IMAGE_PATH:
+            check_and_download_file(PB_IMAGE_PATH, REMOTE_PATH)
+        logger.info("Checking encode_text model...")
+        check_and_download_models(WEIGHT_TEXT_PATH, MODEL_TEXT_PATH, REMOTE_PATH)
+        if PB_TEXT_PATH:
+            check_and_download_file(PB_TEXT_PATH, REMOTE_PATH)
+
+        # initialize
+        if not args.onnx:
+            net_image = ailia.Net(MODEL_IMAGE_PATH, WEIGHT_IMAGE_PATH, env_id=env_id)
+            net_text = ailia.Net(MODEL_TEXT_PATH, WEIGHT_TEXT_PATH, env_id=env_id)
+        else:
+            import onnxruntime
+
+            net_image = onnxruntime.InferenceSession(WEIGHT_IMAGE_PATH)
+            net_text = onnxruntime.InferenceSession(WEIGHT_TEXT_PATH)
+    else:
+        WEIGTH_PATH, MODEL_PATH, PB_PATH = dic_model[model_type]
+
+        check_and_download_models(WEIGTH_PATH, MODEL_PATH, REMOTE_PATH)
+        if PB_PATH:
+            check_and_download_file(PB_PATH, REMOTE_PATH)
+
+        # initialize
+        if not args.onnx:
+            net = ailia.Net(MODEL_PATH, WEIGTH_PATH, env_id=env_id)
+        else:
+            import onnxruntime
+
+            net = onnxruntime.InferenceSession(WEIGTH_PATH)
 
     if args.disable_ailia_tokenizer:
         from transformers import AutoTokenizer
@@ -219,7 +330,15 @@ def main():
 
         tokenizer = GemmaTokenizer.from_pretrained("tokenizer" if model_type == "giant-patch16-256" else "tokenizer-giant")
 
-    models = dict(model_type=model_type, tokenizer=tokenizer, net=net)
+    if args.separate:
+        models = dict(
+            model_type=model_type,
+            tokenizer=tokenizer,
+            net_image=net_image,
+            net_text=net_text,
+        )
+    else:
+        models = dict(model_type=model_type, tokenizer=tokenizer, net=net)
 
     recognize_from_image(models)
 

--- a/image_classification/siglip2/siglip2.py
+++ b/image_classification/siglip2/siglip2.py
@@ -41,6 +41,10 @@ REMOTE_PATH = "https://storage.googleapis.com/ailia-models/siglip2/"
 
 IMAGE_PATH = "demo.jpg"
 
+# The model was trained with fixed-length text and has no attention_mask
+# input, so input_ids must be padded to this length.
+SEQ_LENGTH = 64
+
 
 # ======================
 # Arguemnt Parser Config
@@ -163,10 +167,14 @@ def recognize_from_image(models):
     text_descriptions = [f"This is a photo of a {label}" for label in input_labels]
 
     tokenizer = models["tokenizer"]
+    # ailia tokenizer adds a bos token which is removed below,
+    # so pad to one more token
+    max_length = SEQ_LENGTH if args.disable_ailia_tokenizer else SEQ_LENGTH + 1
     encoded = tokenizer(
         text_descriptions,
         return_tensors="np",
-        padding=True,
+        padding="max_length",
+        max_length=max_length,
         truncation=True,
     )
     input_ids = encoded["input_ids"]


### PR DESCRIPTION
siglip2にencoder-imageとencoder-textを独立して計算できるオプションを追加するPRです。
imageとtextをまとめて計算するモデルから、ONNX2ONNXで独立モデルを出力しました。
--separateオプションで独立モデルを使用可能です。

追加したONNXは下記となります。
https://storage.googleapis.com/ailia-models/siglip2/siglip2-base-patch16-224-encode_image.onnx
https://storage.googleapis.com/ailia-models/siglip2/siglip2-base-patch16-224-encode_text.onnx