### PR TITLE
Add embedder_dynamic.onnx to voicefilter for arbitrary length

### DIFF
--- a/audio_processing/voicefilter/README.md
+++ b/audio_processing/voicefilter/README.md
@@ -44,6 +44,15 @@ You can use `--savepath` option to change the name of the output file to save.
 $ python3 voicefilter.py --input MIXED_WAV --reference_file REFERENCE_WAV --savepath SAVE_PATH
 ```
 
+By default, `embedder_dynamic.onnx` is used, which accepts a reference audio of arbitrary length.
+You can use the `--legacy` option to use the legacy `embedder.onnx`,
+which requires a reference audio of 2.8 sec or longer
+(the sliding windows of unfold were frozen to 6 windows at export time,
+and the extra frames of a reference audio longer than 3 sec are ignored).
+```bash
+$ python3 voicefilter.py --input MIXED_WAV --reference_file REFERENCE_WAV --legacy
+```
+
 
 ## Reference
 
@@ -59,5 +68,6 @@ ONNX opset=11
 
 ## Netron
 
+[embedder_dynamic.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/embedder_dynamic.onnx.prototxt)  
 [embedder.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/embedder.onnx.prototxt)  
 [model.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/model.onnx.prototxt)

--- a/audio_processing/voicefilter/export/export_embedder_dynamic.py
+++ b/audio_processing/voicefilter/export/export_embedder_dynamic.py
@@ -1,0 +1,98 @@
+"""
+Convert embedder.onnx to embedder_dynamic.onnx which accepts an arbitrary
+length reference audio.
+
+The original embedder.onnx was exported by tracing SpeechEmbedder
+(https://github.com/maum-ai/voicefilter) with a 301 frame (3 sec) mel
+spectrogram, so `mel.unfold(1, window=80, stride=40)` was frozen into
+6 fixed Slice + Concat nodes and the LSTM initial states were baked in
+with batch=6. Inputs shorter than 280 frames fail with a Concat shape
+mismatch in ailia.
+
+This script rewrites the graph so that the sliding windows are computed
+at runtime (Shape -> Range -> Gather), which is equivalent to unfold:
+
+    T = Shape(dvec_mel)[1]
+    N = (T - window) / stride + 1
+    starts = Range(0, N, 1) * stride                  # (N,)
+    idx = starts[:, None] + Range(0, window, 1)[None] # (N, window)
+    out = Gather(dvec_mel, idx, axis=1)               # (40, N, window)
+
+and shrinks the all-zero LSTM h0/c0 initializers from (1, 6, 768) to
+(1, 1, 768) so the existing Expand nodes broadcast them to any N.
+
+Usage:
+    python3 export_embedder_dynamic.py [--input ../embedder.onnx] [--output ../embedder_dynamic.onnx]
+"""
+import argparse
+
+import numpy as np
+import onnx
+from onnx import helper, TensorProto
+
+WINDOW = 80
+STRIDE = 40
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--input', default='../embedder.onnx')
+parser.add_argument('--output', default='../embedder_dynamic.onnx')
+args = parser.parse_args()
+
+m = onnx.load(args.input)
+g = m.graph
+
+# Nodes 0..30 are the unrolled unfold:
+# 18x Constant, 6x Slice, 6x Unsqueeze, 1x Concat -> output '45'
+assert g.node[30].op_type == 'Concat' and g.node[30].output[0] == '45'
+del g.node[:31]
+
+
+def const(name, value):
+    arr = np.array(value, dtype=np.int64)
+    return helper.make_node(
+        'Constant', [], [name],
+        value=helper.make_tensor(name + '_t', TensorProto.INT64, arr.shape, arr.flatten()))
+
+
+new_nodes = [
+    # T = Shape(dvec_mel)[1]  (scalar)
+    helper.make_node('Shape', ['dvec_mel'], ['uf_shape']),
+    const('uf_one_s', 1),
+    helper.make_node('Gather', ['uf_shape', 'uf_one_s'], ['uf_T'], axis=0),
+    # N = (T - WINDOW) / STRIDE + 1  (scalar)
+    const('uf_window_s', WINDOW),
+    const('uf_stride_s', STRIDE),
+    helper.make_node('Sub', ['uf_T', 'uf_window_s'], ['uf_Tm']),
+    helper.make_node('Div', ['uf_Tm', 'uf_stride_s'], ['uf_Nd']),
+    helper.make_node('Add', ['uf_Nd', 'uf_one_s'], ['uf_N']),
+    # starts = Range(0, N, 1) * STRIDE  -> (N,)
+    const('uf_zero_s', 0),
+    helper.make_node('Range', ['uf_zero_s', 'uf_N', 'uf_one_s'], ['uf_r']),
+    helper.make_node('Mul', ['uf_r', 'uf_stride_s'], ['uf_starts']),
+    # win = Range(0, WINDOW, 1) -> (WINDOW,)
+    helper.make_node('Range', ['uf_zero_s', 'uf_window_s', 'uf_one_s'], ['uf_win']),
+    # idx = starts[:, None] + win[None, :] -> (N, WINDOW)
+    helper.make_node('Unsqueeze', ['uf_starts'], ['uf_starts2'], axes=[1]),
+    helper.make_node('Unsqueeze', ['uf_win'], ['uf_win2'], axes=[0]),
+    helper.make_node('Add', ['uf_starts2', 'uf_win2'], ['uf_idx']),
+    # gather along time axis: (40, T) -> (40, N, WINDOW)  == old '45'
+    helper.make_node('Gather', ['dvec_mel', 'uf_idx'], ['45'], axis=1),
+]
+for i, n in enumerate(new_nodes):
+    g.node.insert(i, n)
+
+# LSTM h0/c0 were traced as zeros with batch=6 baked in; shrink to batch=1
+# so the Expand nodes can broadcast to any window count N
+for t in g.initializer:
+    a = onnx.numpy_helper.to_array(t)
+    if a.ndim == 3 and a.shape[1] == 6:
+        assert not a.any(), t.name
+        t.CopyFrom(onnx.numpy_helper.from_array(
+            np.zeros((a.shape[0], 1, a.shape[2]), dtype=a.dtype), t.name))
+
+# make the time axis dynamic in the declared input
+g.input[0].type.tensor_type.shape.dim[1].dim_param = 'T'
+
+onnx.checker.check_model(m)
+onnx.save(m, args.output)
+print('saved', args.output)

--- a/audio_processing/voicefilter/voicefilter.py
+++ b/audio_processing/voicefilter/voicefilter.py
@@ -24,8 +24,10 @@ logger = getLogger(__name__)
 
 WEIGHT_PATH = 'model.onnx'
 MODEL_PATH = 'model.onnx.prototxt'
-WEIGHT_EMB_PATH = 'embedder.onnx'
-MODEL_EMB_PATH = 'embedder.onnx.prototxt'
+WEIGHT_EMB_PATH = 'embedder_dynamic.onnx'
+MODEL_EMB_PATH = 'embedder_dynamic.onnx.prototxt'
+WEIGHT_EMB_LEGACY_PATH = 'embedder.onnx'
+MODEL_EMB_LEGACY_PATH = 'embedder.onnx.prototxt'
 REMOTE_PATH = 'https://storage.googleapis.com/ailia-models/voicefilter/'
 
 WAVE_PATH = "mixed.wav"
@@ -45,6 +47,11 @@ parser.add_argument(
     '-r', '--reference_file',
     default="ref-voice.wav", type=str,
     help='path of reference wav file'
+)
+parser.add_argument(
+    '--legacy',
+    action='store_true',
+    help='use the legacy embedder model (requires 3 sec or longer reference audio)'
 )
 args = update_parser(parser)
 
@@ -78,6 +85,16 @@ def audio_recognition(net, embedder):
     # prepare reference wav
     dvec_wav = read_wave(reference_file)
     dvec_mel = audio.get_mel(dvec_wav)
+    if dvec_mel.shape[1] < 80:
+        # the embedder slides a 80 frame (0.8 sec) window over the mel
+        # spectrogram, so at least one full window is required
+        logger.error('the reference audio must be 0.8 sec or longer.')
+        sys.exit(-1)
+    if args.legacy and dvec_mel.shape[1] < 280:
+        logger.error(
+            'the legacy embedder requires 2.8 sec or longer reference audio. '
+            'use a longer reference_file or remove the --legacy option.')
+        sys.exit(-1)
     output = embedder.predict([dvec_mel])
     dvec = output[0]
     dvec = np.expand_dims(dvec, axis=0)
@@ -123,16 +140,21 @@ def audio_recognition(net, embedder):
 
 
 def main():
+    if args.legacy:
+        weight_emb_path, model_emb_path = WEIGHT_EMB_LEGACY_PATH, MODEL_EMB_LEGACY_PATH
+    else:
+        weight_emb_path, model_emb_path = WEIGHT_EMB_PATH, MODEL_EMB_PATH
+
     # model files check and download
     logger.info('Checking voicefilter model...')
     check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
     logger.info('Checking embedder model...')
-    check_and_download_models(WEIGHT_EMB_PATH, MODEL_EMB_PATH, REMOTE_PATH)
+    check_and_download_models(weight_emb_path, model_emb_path, REMOTE_PATH)
 
     env_id = args.env_id
 
     net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
-    embedder = ailia.Net(MODEL_EMB_PATH, WEIGHT_EMB_PATH, env_id=env_id)
+    embedder = ailia.Net(model_emb_path, weight_emb_path, env_id=env_id)
 
     audio_recognition(net, embedder)
 


### PR DESCRIPTION
The original embedder.onnx froze mel.unfold into 6 fixed Slice+Concat nodes and batch=6 LSTM initial states at export time, so reference audio shorter than 2.8 sec failed with a Concat shape mismatch and frames beyond 3 sec were silently ignored.

embedder_dynamic.onnx rewrites the sliding windows as a dynamic Shape/Range/Gather pattern equivalent to unfold and is used by default. The legacy model remains available via the --legacy option.

#1893 