### PR TITLE
Add VoiceSplit pretrained model to voicefilter (-m voicesplit)

### DIFF
--- a/audio_processing/voicefilter/LICENSE_VOICESPLIT
+++ b/audio_processing/voicefilter/LICENSE_VOICESPLIT
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/audio_processing/voicefilter/README.md
+++ b/audio_processing/voicefilter/README.md
@@ -44,6 +44,14 @@ You can use `--savepath` option to change the name of the output file to save.
 $ python3 voicefilter.py --input MIXED_WAV --reference_file REFERENCE_WAV --savepath SAVE_PATH
 ```
 
+By default, the model trained by ailia Inc. is used. You can use the `-m voicesplit` option
+to use the model of [VoiceSplit](https://github.com/Edresson/VoiceSplit), which has the same
+architecture and was trained with the power-law compressed loss of the original paper.
+The same embedder can be used for both models.
+```bash
+$ python3 voicefilter.py --input MIXED_WAV --reference_file REFERENCE_WAV -m voicesplit
+```
+
 By default, `embedder_dynamic.onnx` is used, which accepts a reference audio of arbitrary length.
 You can use the `--legacy` option to use the legacy `embedder.onnx`,
 which requires a reference audio of 2.8 sec or longer
@@ -57,6 +65,7 @@ $ python3 voicefilter.py --input MIXED_WAV --reference_file REFERENCE_WAV --lega
 ## Reference
 
 - [VoiceFilter](https://github.com/mindslab-ai/voicefilter)
+- [VoiceSplit](https://github.com/Edresson/VoiceSplit)
 
 ## Framework
 
@@ -70,4 +79,5 @@ ONNX opset=11
 
 [embedder_dynamic.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/embedder_dynamic.onnx.prototxt)  
 [embedder.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/embedder.onnx.prototxt)  
-[model.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/model.onnx.prototxt)
+[model.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/model.onnx.prototxt)  
+[voicesplit.onnx.prototxt](https://netron.app/?url=https://storage.googleapis.com/ailia-models/voicefilter/voicesplit.onnx.prototxt)

--- a/audio_processing/voicefilter/export/export_voicesplit.py
+++ b/audio_processing/voicefilter/export/export_voicesplit.py
@@ -1,0 +1,66 @@
+"""
+Export the VoiceSplit checkpoint to voicesplit.onnx.
+
+VoiceSplit (https://github.com/Edresson/VoiceSplit) publishes trained
+checkpoints of the VoiceFilter architecture adapted from
+https://github.com/maum-ai/voicefilter (the same implementation the
+existing model.onnx is based on). The "Power-Law" checkpoint uses the
+original paper's power-law compressed loss, the same audio frontend
+(n_fft=1200, hop=160, win=400, num_freq=601, 16kHz) and the same GE2E
+embedder by Seungwon Park, so the exported model is a drop-in
+replacement for model.onnx.
+
+Usage:
+    git clone https://github.com/Edresson/VoiceSplit.git
+    wget "https://github.com/Edresson/VoiceSplit/releases/download/checkpoints/voiceSplit-trained-with-Power-Law-compressed_Loss-GE2E-Seungwonpark-best_checkpoint.pt.pt" -O voicesplit_powerlaw.pt
+    python3 export_voicesplit.py --repo VoiceSplit --checkpoint voicesplit_powerlaw.pt
+"""
+import argparse
+import ast
+import sys
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--repo', default='VoiceSplit', help='path to a clone of Edresson/VoiceSplit')
+parser.add_argument('--checkpoint', default='voicesplit_powerlaw.pt')
+parser.add_argument('--output', default='../voicesplit.onnx')
+args = parser.parse_args()
+
+sys.path.append(args.repo)
+from models.voicefilter.model import VoiceFilter  # noqa: E402
+
+ckpt = torch.load(args.checkpoint, map_location='cpu', weights_only=False)
+config = ast.literal_eval(ckpt['config_str'])
+print('checkpoint step:', ckpt['step'])
+print('audio backend:', config['audio']['backend'])
+print('model config:', config['model'])
+
+model = VoiceFilter(SimpleNamespace(audio=config['audio'], model=config['model']))
+model.load_state_dict(ckpt['model'])
+model.eval()
+
+L = 301  # 3 sec dummy, the time axis is exported as dynamic
+mag = torch.randn(1, L, config['model']['fc2_dim'])
+dvec = torch.randn(1, config['model']['emb_dim'])
+
+torch.onnx.export(
+    model, (mag, dvec), args.output,
+    input_names=['mag', 'dvec'],
+    output_names=['mask'],
+    dynamic_axes={'mag': {1: 'L'}, 'mask': {1: 'L'}},
+    opset_version=11, dynamo=False)
+print('saved', args.output)
+
+# verify against onnxruntime, including a length not seen at export time
+import onnxruntime as ort  # noqa: E402
+sess = ort.InferenceSession(args.output)
+for L in [301, 173]:
+    mag = torch.randn(1, L, config['model']['fc2_dim'])
+    dvec = torch.randn(1, config['model']['emb_dim'])
+    with torch.no_grad():
+        expected = model(mag, dvec).numpy()
+    actual = sess.run(None, {'mag': mag.numpy(), 'dvec': dvec.numpy()})[0]
+    print(f'L={L}: max diff vs torch = {np.abs(expected - actual).max():.3e}')

--- a/audio_processing/voicefilter/voicefilter.py
+++ b/audio_processing/voicefilter/voicefilter.py
@@ -24,6 +24,8 @@ logger = getLogger(__name__)
 
 WEIGHT_PATH = 'model.onnx'
 MODEL_PATH = 'model.onnx.prototxt'
+WEIGHT_VOICESPLIT_PATH = 'voicesplit.onnx'
+MODEL_VOICESPLIT_PATH = 'voicesplit.onnx.prototxt'
 WEIGHT_EMB_PATH = 'embedder_dynamic.onnx'
 MODEL_EMB_PATH = 'embedder_dynamic.onnx.prototxt'
 WEIGHT_EMB_LEGACY_PATH = 'embedder.onnx'
@@ -47,6 +49,12 @@ parser.add_argument(
     '-r', '--reference_file',
     default="ref-voice.wav", type=str,
     help='path of reference wav file'
+)
+parser.add_argument(
+    '-m', '--model', metavar='MODEL',
+    default='voicefilter', choices=('voicefilter', 'voicesplit'),
+    help='model to use: voicefilter (original) or voicesplit '
+         '(VoiceSplit checkpoint trained with the power-law compressed loss)'
 )
 parser.add_argument(
     '--legacy',
@@ -140,20 +148,24 @@ def audio_recognition(net, embedder):
 
 
 def main():
+    if args.model == 'voicesplit':
+        weight_path, model_path = WEIGHT_VOICESPLIT_PATH, MODEL_VOICESPLIT_PATH
+    else:
+        weight_path, model_path = WEIGHT_PATH, MODEL_PATH
     if args.legacy:
         weight_emb_path, model_emb_path = WEIGHT_EMB_LEGACY_PATH, MODEL_EMB_LEGACY_PATH
     else:
         weight_emb_path, model_emb_path = WEIGHT_EMB_PATH, MODEL_EMB_PATH
 
     # model files check and download
-    logger.info('Checking voicefilter model...')
-    check_and_download_models(WEIGHT_PATH, MODEL_PATH, REMOTE_PATH)
+    logger.info('Checking %s model...' % args.model)
+    check_and_download_models(weight_path, model_path, REMOTE_PATH)
     logger.info('Checking embedder model...')
     check_and_download_models(weight_emb_path, model_emb_path, REMOTE_PATH)
 
     env_id = args.env_id
 
-    net = ailia.Net(MODEL_PATH, WEIGHT_PATH, env_id=env_id)
+    net = ailia.Net(model_path, weight_path, env_id=env_id)
     embedder = ailia.Net(model_emb_path, weight_emb_path, env_id=env_id)
 
     audio_recognition(net, embedder)


### PR DESCRIPTION
VoiceSplit (https://github.com/Edresson/VoiceSplit, Apache-2.0) publishes trained checkpoints of the same VoiceFilter architecture with the same audio frontend and the same GE2E embedder. Export the power-law compressed loss checkpoint (step 134500) to voicesplit.onnx and allow switching models with the -m option.

#1893 