### PR TITLE
Add a link to search models by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ python3 yolox.py
 
 # Models
 
-418 models are available.
+418 models are available. Use [🔍 Search models](https://github.com/ailia-ai/ailia-models/find/master) to find a model by name.
 
 | | Category | Models | Sub categories |
 |:---|:---|:---:|:---|


### PR DESCRIPTION
The model list is split by category, so add a link to GitHub's file finder to jump to a model directly when its name is already known.